### PR TITLE
Convert navigation to local stubs

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,0 +1,659 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en" prefix="og: https://ogp.me/ns#">
+<head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# article: http://ogp.me/ns/article#">
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<link rel="shortcut icon" href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2022/12/favicon.png" />
+<link rel="pingback" href="https://www.keisatsubyoin.or.jp/wordpress/xmlrpc.php" />
+<link href="https://use.fontawesome.com/releases/v5.0.10/css/all.css" rel="stylesheet">
+<link rel="stylesheet" href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri-child-1/css/pageheader-style.css" />
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-VTBF3Q2K4B"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-VTBF3Q2K4B');
+</script>
+<!--[if lt IE 9]>
+<script src="https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri/js/html5shiv.min.js"></script>
+<![endif]-->
+<title>About | Tokyo Metropolitan Police Hospital</title>
+
+<!-- All in One SEO 4.7.6 - aioseo.com -->
+<meta name="description" content="Content coming soon." />
+<meta name="robots" content="max-image-preview:large" />
+<meta name="msvalidate.01" content="6025B7F66D63703BEED4E4073634721A" />
+<link rel="canonical" href="./about.html" />
+<meta name="generator" content="All in One SEO (AIOSEO) 4.7.6" />
+
+<meta name="google-site-verification" content="97tlZIAoAnOmR7w1s9-GNtXfEEnBRDb7DyN4QJ3Lv3s" />
+<meta property="og:locale" content="en_US" />
+<meta property="og:site_name" content="Tokyo Metropolitan Police Hospital | Medical Care That Protects Those You Love | Tokyo Metropolitan Police Hospital in Nakano Ward Welcomes All Community Members" />
+<meta property="og:type" content="website" />
+<meta property="og:title" content="About | Tokyo Metropolitan Police Hospital" />
+<meta property="og:description" content="Medical care that protects those you love | Tokyo Metropolitan Police Hospital in Nakano Ward welcomes anyone in the community." />
+<meta property="og:url" content="./about.html" />
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content="About | Tokyo Metropolitan Police Hospital" />
+<meta name="twitter:description" content="Content coming soon." />
+<script type="application/ld+json" class="aioseo-schema">
+{"@context":"https:\/\/schema.org","@graph":[{"@type":"BreadcrumbList","@id":"https:\/\/www.keisatsubyoin.or.jp\/#breadcrumblist","itemListElement":[{"@type":"ListItem","@id":"https:\/\/www.keisatsubyoin.or.jp\/#listItem","position":1,"name":"Home"}]},{"@type":"Organization","@id":"https:\/\/www.keisatsubyoin.or.jp\/#organization","name":"Tokyo Metropolitan Police Hospital","description":"Medical care that protects those you love | Tokyo Metropolitan Police Hospital in Nakano Ward welcomes anyone in the community.","url":"https:\/\/www.keisatsubyoin.or.jp\/"},{"@type":"WebPage","@id":"https:\/\/www.keisatsubyoin.or.jp\/#webpage","url":"https:\/\/www.keisatsubyoin.or.jp\/","name":"Tokyo Metropolitan Police Hospital | Medical Care That Protects Those You Love | Tokyo Metropolitan Police Hospital in Nakano Ward Welcomes All Community Members","description":"Medical care that protects those you love | Tokyo Metropolitan Police Hospital in Nakano Ward welcomes anyone in the community.","inLanguage":"en","isPartOf":{"@id":"https:\/\/www.keisatsubyoin.or.jp\/#website"},"breadcrumb":{"@id":"https:\/\/www.keisatsubyoin.or.jp\/#breadcrumblist"},"datePublished":"2019-12-03T08:15:37+09:00","dateModified":"2025-05-01T10:08:09+09:00"},{"@type":"WebSite","@id":"https:\/\/www.keisatsubyoin.or.jp\/#website","url":"https:\/\/www.keisatsubyoin.or.jp\/","name":"Tokyo Metropolitan Police Hospital","description":"Medical care that protects those you love | Tokyo Metropolitan Police Hospital in Nakano Ward welcomes anyone in the community.","inLanguage":"en","publisher":{"@id":"https:\/\/www.keisatsubyoin.or.jp\/#organization"},"potentialAction":{"@type":"SearchAction","target":{"@type":"EntryPoint","urlTemplate":"https:\/\/www.keisatsubyoin.or.jp\/?s={search_term_string}"},"query-input":"required name=search_term_string"}}]}
+</script>
+<!-- All in One SEO -->
+
+<link rel='dns-prefetch' href='//netdna.bootstrapcdn.com' />
+<link rel="alternate" type="application/rss+xml" title="Tokyo Metropolitan Police Hospital &raquo; Feed" href="https://www.keisatsubyoin.or.jp/feed/" />
+<script type="text/javascript">
+window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/14.0.0\/72x72\/","ext":".png","svgUrl":"https:\/\/s.w.org\/images\/core\/emoji\/14.0.0\/svg\/","svgExt":".svg","source":{"concatemoji":"https:\/\/www.keisatsubyoin.or.jp\/wordpress\/wp-includes\/js\/wp-emoji-release.min.js?ver=6.2.8"}};
+/*! This file is auto-generated */
+!function(e,a,t){var n,r,o,i=a.createElement("canvas"),p=i.getContext&&i.getContext("2d");function s(e,t){p.clearRect(0,0,i.width,i.height),p.fillText(e,0,0);e=i.toDataURL();return p.clearRect(0,0,i.width,i.height),p.fillText(t,0,0),e===i.toDataURL()}function c(e){var t=a.createElement("script");t.src=e,t.defer=t.type="text/javascript",a.getElementsByTagName("head")[0].appendChild(t)}for(o=Array("flag","emoji"),t.supports={everything:!0,everythingExceptFlag:!0},r=0;r<o.length;r++)t.supports[o[r]]=function(e){if(p&&p.fillText)switch(p.textBaseline="top",p.font="600 32px Arial",e){case"flag":return s("\ud83c\udff3\ufe0f\u200d\u26a7\ufe0f","\ud83c\udff3\ufe0f\u200b\u26a7\ufe0f")?!1:!s("\ud83c\uddfa\ud83c\uddf3","\ud83c\uddfa\u200b\ud83c\uddf3")&&!s("\ud83c\udff4\udb40\udc67\udb40\udc62\udb40\udc65\udb40\udc6e\udb40\udc67\udb40\udc7f","\ud83c\udff4\u200b\udb40\udc67\u200b\udb40\udc62\u200b\udb40\udc65\u200b\udb40\udc6e\u200b\udb40\udc67\u200b\udb40\udc7f");case"emoji":return!s("\ud83e\udef1\ud83c\udffb\u200d\ud83e\udef2\ud83c\udfff","\ud83e\udef1\ud83c\udffb\u200b\ud83e\udef2\ud83c\udfff")}return!1}(o[r]),t.supports.everything=t.supports.everything&&t.supports[o[r]],"flag"!==o[r]&&(t.supports.everythingExceptFlag=t.supports.everythingExceptFlag&&t.supports[o[r]]);t.supports_everythingExceptFlag=t.supports.everythingExceptFlag&&!t.supports.flag,t.DOMReady=!1,t.readyCallback=function(){t.DOMReady=!0},t.supports.everything||(n=function(){t.readyCallback()},a.addEventListener?(a.addEventListener("DOMContentLoaded",n,!1),e.addEventListener("load",n,!1)):(e.attachEvent("onload",n),a.attachEvent("onreadystatechange",function(){"complete"===a.readyState&&t.readyCallback()})),(e=t.source||{}).concatemoji?c(e.concatemoji):e.wpemoji&&e.twemoji&&(c(e.twemoji),c(e.wpemoji)))}(window,document,window._wpemojiSettings);
+</script>
+<style type="text/css">
+img.wp-smiley,
+img.emoji {
+display: inline !important;
+border: none !important;
+box-shadow: none !important;
+height: 1em !important;
+width: 1em !important;
+margin: 0 0.07em !important;
+vertical-align: -0.1em !important;
+background: none !important;
+padding: 0 !important;
+}
+</style>
+<link rel='stylesheet' id='wp-block-library-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-includes/css/dist/block-library/style.min.css?ver=6.2.8' type='text/css' media='all' />
+<style id='pdfemb-pdf-embedder-viewer-style-inline-css' type='text/css'>
+.wp-block-pdfemb-pdf-embedder-viewer{max-width:none}
+
+</style>
+<link rel='stylesheet' id='awsm-ead-public-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/embed-any-document/css/embed-public.min.css?ver=2.7.4' type='text/css' media='all' />
+<link rel='stylesheet' id='classic-theme-styles-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-includes/css/classic-themes.min.css?ver=6.2.8' type='text/css' media='all' />
+<style id='global-styles-inline-css' type='text/css'>
+body{
+--wp--preset--color--black: #000000;
+--wp--preset--color--cyan-bluish-gray: #abb8c3;
+--wp--preset--color--white: #ffffff;
+--wp--preset--color--pale-pink: #f78da7;
+--wp--preset--color--vivid-red: #cf2e2e;
+--wp--preset--color--luminous-vivid-orange: #ff6900;
+--wp--preset--color--luminous-vivid-amber: #fcb900;
+--wp--preset--color--light-green-cyan: #7bdcb5;
+--wp--preset--color--vivid-green-cyan: #00d084;
+--wp--preset--color--pale-cyan-blue: #8ed1fc;
+--wp--preset--color--vivid-cyan-blue: #0693e3;
+--wp--preset--color--vivid-purple: #9b51e0;
+--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%);
+--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan: linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%);
+--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange: linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%);
+--wp--preset--gradient--luminous-vivid-orange-to-vivid-red: linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%);
+--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray: linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%);
+--wp--preset--gradient--cool-to-warm-spectrum: linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186) 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%);
+--wp--preset--gradient--blush-light-purple: linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%);
+--wp--preset--gradient--blush-bordeaux: linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%);
+--wp--preset--gradient--luminous-dusk: linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%);
+--wp--preset--gradient--pale-ocean: linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181) 100%);
+--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128) 0%,rgb(113,206,126) 100%);
+--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%);
+--wp--preset--duotone--dark-grayscale: url('#wp-duotone-dark-grayscale');
+--wp--preset--duotone--grayscale: url('#wp-duotone-grayscale');
+--wp--preset--duotone--purple-yellow: url('#wp-duotone-purple-yellow');
+--wp--preset--duotone--blue-red: url('#wp-duotone-blue-red');
+--wp--preset--duotone--midnight: url('#wp-duotone-midnight');
+--wp--preset--duotone--magenta-yellow: url('#wp-duotone-magenta-yellow');
+--wp--preset--duotone--purple-green: url('#wp-duotone-purple-green');
+--wp--preset--duotone--blue-orange: url('#wp-duotone-blue-orange');
+--wp--preset--font-size--small: 13px;
+--wp--preset--font-size--medium: 20px;
+--wp--preset--font-size--large: 36px;
+--wp--preset--font-size--x-large: 42px;
+--wp--preset--spacing--20: 0.44rem;
+--wp--preset--spacing--30: 0.67rem;
+--wp--preset--spacing--40: 1rem;
+--wp--preset--spacing--50: 1.5rem;
+--wp--preset--spacing--60: 2.25rem;
+--wp--preset--spacing--70: 3.38rem;
+--wp--preset--spacing--80: 5.06rem;
+--wp--preset--shadow--natural: 6px 6px 9px rgba(0, 0, 0, 0.2);
+--wp--preset--shadow--deep: 12px 12px 50px rgba(0, 0, 0, 0.4);
+--wp--preset--shadow--sharp: 6px 6px 0px rgba(0, 0, 0, 0.2);
+--wp--preset--shadow--outlined: 6px 6px 0px -3px rgba(255, 255, 255, 1), 6px 6px rgba(0, 0, 0, 1);
+--wp--preset--shadow--crisp: 6px 6px 0px rgba(0, 0, 0, 1);
+}
+:where(.is-layout-flex){gap: 0.5em;}
+body .is-layout-flow > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}
+body .is-layout-flow > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}
+body .is-layout-flow > .aligncenter{margin-left: auto !important;margin-right: auto !important;}
+body .is-layout-constrained > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}
+body .is-layout-constrained > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}
+body .is-layout-constrained > .aligncenter{margin-left: auto !important;margin-right: auto !important;}
+body .is-layout-constrained > :where(:not(.alignleft):not(.alignright):not(.alignfull)){max-width: var(--wp--style--global--content-size);margin-left: auto !important;margin-right: auto !important;}
+body .is-layout-constrained > .alignwide{max-width: var(--wp--style--global--wide-size);}
+body .is-layout-flex{display: flex;}
+body .is-layout-flex{flex-wrap: wrap;align-items: center;}
+body .is-layout-flex > *{margin: 0;}
+:where(.wp-block-columns.is-layout-flex){gap: 2em;}
+.has-black-color{color: var(--wp--preset--color--black) !important;}
+.has-cyan-bluish-gray-color{color: var(--wp--preset--color--cyan-bluish-gray) !important;}
+.has-white-color{color: var(--wp--preset--color--white) !important;}
+.has-pale-pink-color{color: var(--wp--preset--color--pale-pink) !important;}
+.has-vivid-red-color{color: var(--wp--preset--color--vivid-red) !important;}
+.has-luminous-vivid-orange-color{color: var(--wp--preset--color--luminous-vivid-orange) !important;}
+.has-luminous-vivid-amber-color{color: var(--wp--preset--color--luminous-vivid-amber) !important;}
+.has-light-green-cyan-color{color: var(--wp--preset--color--light-green-cyan) !important;}
+.has-vivid-green-cyan-color{color: var(--wp--preset--color--vivid-green-cyan) !important;}
+.has-pale-cyan-blue-color{color: var(--wp--preset--color--pale-cyan-blue) !important;}
+.has-vivid-cyan-blue-color{color: var(--wp--preset--color--vivid-cyan-blue) !important;}
+.has-vivid-purple-color{color: var(--wp--preset--color--vivid-purple) !important;}
+.has-black-background-color{background-color: var(--wp--preset--color--black) !important;}
+.has-cyan-bluish-gray-background-color{background-color: var(--wp--preset--color--cyan-bluish-gray) !important;}
+.has-white-background-color{background-color: var(--wp--preset--color--white) !important;}
+.has-pale-pink-background-color{background-color: var(--wp--preset--color--pale-pink) !important;}
+.has-vivid-red-background-color{background-color: var(--wp--preset--color--vivid-red) !important;}
+.has-luminous-vivid-orange-background-color{background-color: var(--wp--preset--color--luminous-vivid-orange) !important;}
+.has-luminous-vivid-amber-background-color{background-color: var(--wp--preset--color--luminous-vivid-amber) !important;}
+.has-light-green-cyan-background-color{background-color: var(--wp--preset--color--light-green-cyan) !important;}
+.has-vivid-green-cyan-background-color{background-color: var(--wp--preset--color--vivid-green-cyan) !important;}
+.has-pale-cyan-blue-background-color{background-color: var(--wp--preset--color--pale-cyan-blue) !important;}
+.has-vivid-cyan-blue-background-color{background-color: var(--wp--preset--color--vivid-cyan-blue) !important;}
+.has-vivid-purple-background-color{background-color: var(--wp--preset--color--vivid-purple) !important;}
+.has-black-border-color{border-color: var(--wp--preset--color--black) !important;}
+.has-cyan-bluish-gray-border-color{border-color: var(--wp--preset--color--cyan-bluish-gray) !important;}
+.has-white-border-color{border-color: var(--wp--preset--color--white) !important;}
+.has-pale-pink-border-color{border-color: var(--wp--preset--color--pale-pink) !important;}
+.has-vivid-red-border-color{border-color: var(--wp--preset--color--vivid-red) !important;}
+.has-luminous-vivid-orange-border-color{border-color: var(--wp--preset--color--luminous-vivid-orange) !important;}
+.has-luminous-vivid-amber-border-color{border-color: var(--wp--preset--color--luminous-vivid-amber) !important;}
+.has-light-green-cyan-border-color{border-color: var(--wp--preset--color--light-green-cyan) !important;}
+.has-vivid-green-cyan-border-color{border-color: var(--wp--preset--color--vivid-green-cyan) !important;}
+.has-pale-cyan-blue-border-color{border-color: var(--wp--preset--color--pale-cyan-blue) !important;}
+.has-vivid-cyan-blue-border-color{border-color: var(--wp--preset--color--vivid-cyan-blue) !important;}
+.has-vivid-purple-border-color{border-color: var(--wp--preset--color--vivid-purple) !important;}
+.has-vivid-cyan-blue-to-vivid-purple-gradient-background{background: var(--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple) !important;}
+.has-light-green-cyan-to-vivid-green-cyan-gradient-background{background: var(--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan) !important;}
+.has-luminous-vivid-amber-to-luminous-vivid-orange-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange) !important;}
+.has-luminous-vivid-orange-to-vivid-red-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-orange-to-vivid-red) !important;}
+.has-very-light-gray-to-cyan-bluish-gray-gradient-background{background: var(--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray) !important;}
+.has-cool-to-warm-spectrum-gradient-background{background: var(--wp--preset--gradient--cool-to-warm-spectrum) !important;}
+.has-blush-light-purple-gradient-background{background: var(--wp--preset--gradient--blush-light-purple) !important;}
+.has-blush-bordeaux-gradient-background{background: var(--wp--preset--gradient--blush-bordeaux) !important;}
+.has-luminous-dusk-gradient-background{background: var(--wp--preset--gradient--luminous-dusk) !important;}
+.has-pale-ocean-gradient-background{background: var(--wp--preset--gradient--pale-ocean) !important;}
+.has-electric-grass-gradient-background{background: var(--wp--preset--gradient--electric-grass) !important;}
+.has-midnight-gradient-background{background: var(--wp--preset--gradient--midnight) !important;}
+.has-small-font-size{font-size: var(--wp--preset--font-size--small) !important;}
+.has-medium-font-size{font-size: var(--wp--preset--font-size--medium) !important;}
+.has-large-font-size{font-size: var(--wp--preset--font-size--large) !important;}
+.has-x-large-font-size{font-size: var(--wp--preset--font-size--x-large) !important;}
+.wp-block-navigation a:where(:not(.wp-element-button)){color: inherit;}
+:where(.wp-block-columns.is-layout-flex){gap: 2em;}
+.wp-block-pullquote{font-size: 1.5em;line-height: 1.6;}
+</style>
+<link rel='stylesheet' id='font-awesome-css' href='//netdna.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.css' type='text/css' media='screen' />
+<link rel='stylesheet' id='habakiri-assets-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri/css/assets.min.css?ver=6.2.8' type='text/css' media='all' />
+<link rel='stylesheet' id='habakiri-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri/style.min.css?ver=20250926050751' type='text/css' media='all' />
+<link rel='stylesheet' id='habakiri-child-1-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri-child-1/style.css?ver=20250926050751' type='text/css' media='all' />
+<link rel='stylesheet' id='msl-main-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/master-slider/public/assets/css/masterslider.main.css?ver=3.10.0' type='text/css' media='all' />
+<link rel='stylesheet' id='msl-custom-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/master-slider/custom.css?ver=4.5' type='text/css' media='all' />
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-includes/js/jquery/jquery.min.js?ver=3.6.4' id='jquery-core-js'></script>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-includes/js/jquery/jquery-migrate.min.js?ver=3.4.0' id='jquery-migrate-js'></script>
+<link rel="https://api.w.org/" href="https://www.keisatsubyoin.or.jp/wp-json/" /><link rel="alternate" type="application/json" href="https://www.keisatsubyoin.or.jp/wp-json/wp/v2/pages/22" /><link rel="EditURI" type="application/rsd+xml" title="RSD" href="https://www.keisatsubyoin.or.jp/wordpress/xmlrpc.php?rsd" />
+<link rel="wlwmanifest" type="application/wlwmanifest+xml" href="https://www.keisatsubyoin.or.jp/wordpress/wp-includes/wlwmanifest.xml" />
+<meta name="generator" content="WordPress 6.2.8" />
+<link rel='shortlink' href='https://www.keisatsubyoin.or.jp/' />
+<link rel="alternate" type="application/json+oembed" href="https://www.keisatsubyoin.or.jp/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.keisatsubyoin.or.jp%2F" />
+<link rel="alternate" type="text/xml+oembed" href="https://www.keisatsubyoin.or.jp/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.keisatsubyoin.or.jp%2F&#038;format=xml" />
+<script>var ms_grabbing_curosr = 'https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/master-slider/public/assets/css/common/grabbing.cur', ms_grab_curosr = 'https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/master-slider/public/assets/css/common/grab.cur';</script>
+<meta name="generator" content="MasterSlider 3.10.0 - Responsive Touch Image Slider | avt.li/msf" />
+
+<style>
+.scroll-back-to-top-wrapper {
+    position: fixed;
+opacity: 0;
+visibility: hidden;
+overflow: hidden;
+text-align: center;
+z-index: 99999999;
+    background-color: #777777;
+color: #eeeeee;
+width: 50px;
+height: 48px;
+line-height: 48px;
+right: 30px;
+bottom: 60px;
+padding-top: 2px;
+border-top-left-radius: 10px;
+border-top-right-radius: 10px;
+border-bottom-right-radius: 10px;
+border-bottom-left-radius: 10px;
+-webkit-transition: all 0.5s ease-in-out;
+-moz-transition: all 0.5s ease-in-out;
+-ms-transition: all 0.5s ease-in-out;
+-o-transition: all 0.5s ease-in-out;
+transition: all 0.5s ease-in-out;
+}
+.scroll-back-to-top-wrapper:hover {
+background-color: #888888;
+  color: #eeeeee;
+}
+.scroll-back-to-top-wrapper.show {
+    visibility:visible;
+    cursor:pointer;
+opacity: 1.0;
+}
+.scroll-back-to-top-wrapper i.fa {
+line-height: inherit;
+}
+.scroll-back-to-top-wrapper .fa-lg {
+vertical-align: 0;
+}
+</style><style>
+/* Safari 6.1+ (10.0 is the latest version of Safari at this time) */
+@media (max-width: 991px) and (min-color-index: 0) and (-webkit-min-device-pixel-ratio: 0) { @media () {
+display: block !important;
+.header__col {
+width: 100%;
+}
+}}
+</style>
+<style>a{color:#337ab7}a:focus,a:active,a:hover{color:#23527c}.site-branding a{color:#000}.responsive-nav a{color:#ffffff;font-size:14px}.responsive-nav a small{color:#707070;font-size:10px}.responsive-nav a:hover small,.responsive-nav a:active small,.responsive-nav .current-menu-item small,.responsive-nav .current-menu-ancestor small,.responsive-nav .current-menu-parent small,.responsive-nav .current_page_item small,.responsive-nav .current_page_parent small{color:#707070}.responsive-nav .menu>.menu-item>a,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.menu-item>a{background-color:#f4a000;padding:12px 7px}.responsive-nav .menu>.menu-item>a:hover,.responsive-nav .menu>.menu-item>a:active,.responsive-nav .menu>.current-menu-item>a,.responsive-nav .menu>.current-menu-ancestor>a,.responsive-nav .menu>.current-menu-parent>a,.responsive-nav .menu>.current_page_item>a,.responsive-nav .menu>.current_page_parent>a,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.menu-item>a:hover,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.menu-item>a:active,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.current-menu-item>a,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.current-menu-ancestor>a,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.current-menu-parent>a,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.current_page_item>a,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.current_page_parent>a{background-color:#f5f5f5;color:#707070}.responsive-nav .sub-menu a{background-color:#f5f5f5;color:#707070}.responsive-nav .sub-menu a:hover,.responsive-nav .sub-menu a:active,.responsive-nav .sub-menu .current-menu-item a,.responsive-nav .sub-menu .current-menu-ancestor a,.responsive-nav .sub-menu .current-menu-parent a,.responsive-nav .sub-menu .current_page_item a,.responsive-nav .sub-menu .current_page_parent a{background-color:#f5f5f5;color:#707070}.off-canvas-nav{font-size:12px}.responsive-nav,.header--transparency.header--fixed--is_scrolled .responsive-nav{background-color:#f4a000}#responsive-btn{background-color:transparent;border-color:#eeeeee;color:#000}#responsive-btn:hover{background-color:#f5f5f5;border-color:#eee;color:#000}.habakiri-slider__transparent-layer{background-color:rgba( 0,0,0, 0.1 )}.page-header{background-color:#dddddd;color:#fff}.pagination>li>a{color:#337ab7}.pagination>li>span{background-color:#337ab7;border-color:#337ab7}.pagination>li>a:focus,.pagination>li>a:hover,.pagination>li>span:focus,.pagination>li>span:hover{color:#23527c}.header{background-color:#fff}.header--transparency.header--fixed--is_scrolled{background-color:#fff !important}.footer{background-color:#f49000}.footer-widget-area a{color:#777}.footer-widget-area,.footer-widget-area .widget_calendar #wp-calendar caption{color:#555}.footer-widget-area .widget_calendar #wp-calendar,.footer-widget-area .widget_calendar #wp-calendar *{border-color:#555}@media(min-width:992px){.responsive-nav{display:block}.off-canvas-nav,#responsive-btn{display:none !important}.header--2row{padding-bottom:0}.header--2row .header__col,.header--center .header__col{display:block}.header--2row .responsive-nav,.header--center .responsive-nav{margin-right:-1000px;margin-left:-1000px;padding-right:1000px;padding-left:1000px}.header--center .site-branding{text-align:center}}</style><link rel="icon" href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2022/12/favicon.png" sizes="32x32" />
+<link rel="icon" href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2022/12/favicon.png" sizes="192x192" />
+<link rel="apple-touch-icon" href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2022/12/favicon.png" />
+<meta name="msapplication-TileImage" content="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2022/12/favicon.png" />
+<style type="text/css" id="wp-custom-css">
+.cl_rd {
+color: #F00;
+}
+.responsive-nav .sub-menu a {
+background-color: #f5f5f5;
+color: #707070;
+font-weight:bold
+}
+body{
+  word-wrap : break-word;
+  overflow-wrap : break-word;
+}
+
+img {
+    -webkit-backface-visibility: hidden;
+}
+@media print {
+.scroll-back-to-top-wrapper{
+display: none !important;
+}
+}
+
+.spmenu2 {
+             padding:  10px 0 0;
+    }
+@media screen and (max-width: 991px) {
+    .spmenu {
+       /* border-bottom: solid 1px #ffcf74;*/
+        padding:  0 0 10px;
+width: 100%;
+    }
+}</style>
+</head>
+<body data-rsssl=1 class="home page-template page-template-templates page-template-rich-front-page page-template-templatesrich-front-page-php page page-id-22 _masterslider _ms_version_3.10.0">
+<div id="container">
+<header id="header" class="header header--2row ">
+<div class="container">
+<div class="row header__content">
+<div class="col-xs-10 col-md-12 header__col">
+<div class ="row">
+<div class="col-md-6 col-sm-12">
+
+<div class="site-branding">
+<h1 class="site-branding__heading">
+<a href="./index.html" rel="home"><img src="https://keisatsubyoin.or.jp/wordpress/wp-content/uploads/2020/03/logo.png" alt="Tokyo Metropolitan Police Hospital" class="site-branding__logo" /></a></h1>
+<!-- end .site-branding --></div>
+                        </div>
+<div class="col-md-6 col-sm-12 h-btn-flex">
+<div id="site-cr">
+<a href="./index.html" class="h-btn current">Website for Patients</a>
+<a href="https://www.keisatsubyoin.or.jp/m/" class="h-btn">Website for Healthcare Professionals</a>
+</div>
+                        <ul class="topnav2">
+<li class="f-cv-tel"><i class="fas fa-phone-volume"></i>03-5343-5611<span style="font-size:12px"> (Main)</span><!--<span class="h-time">【Reception Hours】8:00~11:30/12:30~16:00</span>--></li>
+</ul>
+                        </div>
+                 </div>
+         <!-- end .header__col --></div>
+<div class="col-xs-2 col-md-12 header__col global-nav-wrapper clearfix">
+
+<nav class="global-nav js-responsive-nav nav--hide" role="navigation">
+<div class="menu-gnavi-container"><ul id="menu-gnavi" class="menu"><li id="menu-item-35" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-35"><a href="./index.html"><div class="m-icon"><i class="fas fa-home"></i>Home</div></a></li>
+<li id="menu-item-157" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-157"><a href="./outpatient.html"><div class="m-icon"><i class="fas fa-stethoscope"></i>Outpatient Visits</div></a>
+<ul class="sub-menu">
+<li id="menu-item-170" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-170"><a href="./outpatient.html">For First-Time Patients</a></li>
+<li id="menu-item-172" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-172"><a href="./outpatient.html">For Returning Patients</a></li>
+<li id="menu-item-12181" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-12181"><a href="./outpatient.html">About Nighttime &amp; Holiday Clinics</a></li>
+<li id="menu-item-171" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-171"><a href="./outpatient.html">For Patients with Referral Letters</a></li>
+<li id="menu-item-10898" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-10898"><a href="./outpatient.html">About Focused Referral Medical Institutions</a></li>
+<li id="menu-item-169" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-169"><a href="./outpatient.html">Community Primary Care Physicians</a></li>
+<li id="menu-item-158" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-158"><a href="./outpatient.html">About Medications</a></li>
+</ul>
+</li>
+<li id="menu-item-32" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-32"><a href="./departments.html"><div class="m-icon"><i class="fas fa-syringe"></i>Departments &amp; Divisions</div></a></li>
+<li id="menu-item-190" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-190"><a href="./inpatient.html"><div class="m-icon"><i class="fas fa-bed"></i>Inpatient Guide</div></a>
+<ul class="sub-menu">
+<li id="menu-item-194" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-194"><a href="./inpatient.html">Admission &amp; Discharge</a></li>
+<li id="menu-item-191" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-191"><a href="./inpatient.html">For Visitors</a></li>
+<li id="menu-item-193" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-193"><a href="./inpatient.html">Life During Hospitalization</a></li>
+<li id="menu-item-196" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-196"><a href="./inpatient.html">About Patient Rooms</a></li>
+<li id="menu-item-192" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-192"><a href="./inpatient.html">Messages to Inpatients</a></li>
+<li id="menu-item-195" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-195"><a href="./inpatient.html">About DPC</a></li>
+</ul>
+</li>
+<li id="menu-item-332" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-332"><a href="./about.html"><div class="m-icon"><i class="fas fa-hospital-alt"></i>About the Hospital</div></a>
+<ul class="sub-menu">
+<li id="menu-item-330" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-330"><a href="./about.html">Message from the Hospital Director</a></li>
+<li id="menu-item-338" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-338"><a href="./about.html">Overview &amp; History</a></li>
+<li id="menu-item-318" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-318"><a href="./about.html">Philosophy &amp; Core Policies</a></li>
+<li id="menu-item-5336" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-5336"><a href="./about.html">Policy on Refusal of Blood Transfusions</a></li>
+<li id="menu-item-317" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-317"><a href="./about.html">Patients' Rights &amp; Responsibilities</a></li>
+<li id="menu-item-7761" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-7761"><a href="./about.html">Request for Comprehensive Consent</a></li>
+<li id="menu-item-319" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-319"><a href="./about.html">Partnership with Patients</a></li>
+<li id="menu-item-329" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-329"><a href="./about.html">Facility Guide</a></li>
+<li id="menu-item-321" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-321"><a href="./about.html">Professional Accreditations</a></li>
+<li id="menu-item-322" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-322"><a href="./about.html">Advanced Medical Equipment</a></li>
+<li id="menu-item-323" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-323"><a href="./about.html">Accredited Hospital Functions</a></li>
+<li id="menu-item-325" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-325"><a href="./about.html">Tokyo Police Hospital by the Numbers</a></li>
+<li id="menu-item-4097" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4097"><a href="https://www.keisatsubyoin.or.jp/privacy/">Privacy Policy</a></li>
+<li id="menu-item-4098" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4098"><a href="https://www.keisatsubyoin.or.jp/nextgeneration/">Next Generation Development Support Measures</a></li>
+<li id="menu-item-4099" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4099"><a href="https://www.keisatsubyoin.or.jp/josei/">Women's Advancement Promotion Plan</a></li>
+<li id="menu-item-4197" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4197"><a href="./about.html">Notices Required by the Minister of Health, Labour and Welfare</a></li>
+</ul>
+</li>
+<li id="menu-item-357" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-357"><a href="./support.html"><div class="m-icon"><i class="fas fa-comment-dots"></i>Consultation &amp; Support</div></a>
+<ul class="sub-menu">
+<li id="menu-item-364" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-364"><a href="./support.html">Information Desk</a></li>
+<li id="menu-item-365" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-365"><a href="./support.html">About Second Opinions</a></li>
+<li id="menu-item-362" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-362"><a href="./support.html">Nutrition Counseling &amp; Guidance</a></li>
+<li id="menu-item-361" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-361"><a href="./support.html">Medical Social Services</a></li>
+<li id="menu-item-359" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-359"><a href="./support.html">Access to Medical Records</a></li>
+<li id="menu-item-358" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-358"><a href="./support.html">Clinical Support Team</a></li>
+<li id="menu-item-360" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-360"><a href="./support.html">Frequently Asked Questions</a></li>
+<li id="menu-item-363" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-363"><a href="./support.html">Patient Safety</a></li>
+<li id="menu-item-1573" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1573"><a href="./support.html">Telephone Use</a></li>
+<li id="menu-item-4209" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4209"><a href="./support.html">Suggestion Box</a></li>
+<li id="menu-item-1577" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-1577"><a href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2023/03/患者さま図書コーナーのご案内.pdf">Patient Library Corner</a></li>
+<li id="menu-item-4100" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4100"><a href="https://www.keisatsubyoin.or.jp/news_090821_dog/">Assistance Dogs for Persons with Disabilities</a></li>
+<li id="menu-item-4101" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4101"><a href="https://www.keisatsubyoin.or.jp/research/">Clinical Trials &amp; Research</a></li>
+</ul>
+</li>
+<li id="menu-item-31" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-31"><a href="./access.html"><div class="m-icon"><i class="fas fa-map-marker-alt"></i>Access</div></a></li>
+</ul></div><!-- end .global-nav --></nav>
+<div id="responsive-btn"></div>
+</div>
+<!-- end .header__col --></div>
+<!-- end .container --></div>
+<!-- end #header --></header>
+<div id="contents">
+  <main class="container" role="main">
+    <h1>About the Hospital</h1>
+    <p>Content coming soon.</p>
+  </main>
+<!-- end #contents --></div>
+<footer id="footer" class="footer">
+
+
+<div class="f-menuArea">
+<div class="container">
+<ul class="f-menu">
+<li>
+<div class="spmenu"><i class="fas fa-chevron-right"></i><a href="./outpatient.html">Outpatient Visits</a></div>
+<ul class="f-sub-menu">
+<li><a href="./outpatient.html">For First-Time Patients</a></li>
+<li><a href="./outpatient.html">For Returning Patients</a></li>
+<li><a href="./outpatient.html">Nighttime &amp; Holiday (After-Hours) Clinics</a></li>
+<li><a href="./outpatient.html">For Patients with Referral Letters</a></li>
+<li><a href="./outpatient.html">About Focused Referral Medical Institutions</a></li>
+<li><a href="./outpatient.html">Keep a Community Primary Care Physician</a></li>
+<li><a href="./outpatient.html">About Medications</a></li>
+</ul>
+<div class="spmenu2"><i class="fas fa-chevron-right"></i><a href="./departments.html">Departments &amp; Divisions</a></div>
+</li>
+<li><i class="fas fa-chevron-right"></i><a href="./inpatient.html">Inpatient Guide</a>
+<ul class="f-sub-menu">
+<li><a href="./inpatient.html">About Admission &amp; Discharge</a></li>
+<li><a href="./inpatient.html">For Visitors</a></li>
+<li><a href="./inpatient.html">Life During Hospitalization</a></li>
+<li><a href="./inpatient.html">About Patient Rooms</a></li>
+<li><a href="./inpatient.html">About Messages to Patients</a></li>
+<li><a href="./inpatient.html">About DPC</a></li>
+</ul>
+</li>
+<li><i class="fas fa-chevron-right"></i><a href="./about.html">About the Hospital</a>
+<ul class="f-sub-menu">
+<li><a href="./about.html">Message from the Hospital Director</a></li>
+<li><a href="./about.html">Hospital Overview</a></li>
+<li><a href="./about.html">Philosophy / Core Policies</a></li>
+<li><a href="./about.html">Policy on Refusal of Blood Transfusions</a></li>
+<li><a href="./about.html">Patients' Rights &amp; Responsibilities</a></li>
+<li><a href="./about.html">Request for Comprehensive Consent</a></li>
+<li><a href="./about.html">Partnership with Patients</a></li>
+<!--<li><a href="./about.html">Organization / Committees</a></li>-->
+<li><a href="./about.html">Floor Guide / On-Site Services</a></li>
+<li><a href="./about.html">Professional Accreditations</a></li>
+<li><a href="./about.html">Advanced Medical Equipment</a></li>
+<li><a href="./about.html">Hospital Function Accreditation</a></li>
+<li><a href="./about.html">Tokyo Police Hospital by the Numbers (Clinical Indicators)</a></li>
+<!--<li><a href="./about.html">History</a></li>-->
+<li><a href="https://www.keisatsubyoin.or.jp/privacy/">Privacy Policy</a></li>
+<li><a href="https://www.keisatsubyoin.or.jp/nextgeneration/">Next Generation Development Support Measures</a></li>
+<li><a href="https://www.keisatsubyoin.or.jp/josei/">Women's Advancement Promotion Plan</a></li>
+<li><a href="./about.html">Notices Required by the Minister of Health, Labour and Welfare</a></li>
+<li><a href="https://www.keisatsubyoin.or.jp/sitemap/">Site Map</a></li>
+</ul>
+</li>
+<li><div class="spmenu"><i class="fas fa-chevron-right"></i><a href="./support.html">Consultation &amp; Support</a></div>
+<ul class="f-sub-menu">
+<li><a href="./support.html">Information Desk</a></li>
+<li><a href="./support.html">Second Opinions</a></li>
+<li><a href="./support.html">Meals &amp; Nutrition Guidance</a></li>
+<li><a href="./support.html">Medical Social Services</a></li>
+<li><a href="./support.html">Access to Medical Records</a></li>
+<li><a href="./support.html">Clinical Support</a></li>
+<li><a href="./support.html">Frequently Asked Questions</a></li>
+<li><a href="./support.html">Patient Safety &amp; Infection Control</a></li>
+<li><a href="./support.html">Telephone Use</a></li>
+<li><a href="./support.html">Suggestion Box</a></li>
+<li><a href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2023/03/患者さま図書コーナーのご案内.pdf">Patient Library Corner</a></li>
+<!--<li><a href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2020/02/vol.11_Kanjasama-Tosyo.pdf#page=1&zoom=200">Patient Library Corner</a></li>-->
+<li><a href="https://www.keisatsubyoin.or.jp/news_090821_dog/">Assistance Dogs for Persons with Disabilities</a></li>
+<li><a href="https://www.keisatsubyoin.or.jp/research/">Clinical Trials &amp; Research</a></li>
+</ul>
+<div class="spmenu2"><i class="fas fa-chevron-right"></i><a href="./access.html">Access</a></div>
+</li>
+</ul>
+</div>
+</div>
+<div class="copyright">
+<div class="container">
+&copy; Tokyo Metropolitan Police Hospital 4-22-1 Nakano, Nakano-ku, Tokyo
+<!-- end .container --></div>
+<!-- end .copyright --></div>
+<!-- end #footer --></footer>
+<!-- end #container --></div>
+<div class="scroll-back-to-top-wrapper">
+<span class="scroll-back-to-top-inner">
+<i class="fa fa-2x fa-arrow-circle-up"></i>
+</span>
+</div><script>
+jQuery( function( $ ) {
+$( '.js-responsive-nav' ).responsive_nav( {
+direction: 'right'
+} );
+} );
+</script>
+<link rel='stylesheet' id='metaslider-flex-slider-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/ml-slider/assets/sliders/flexslider/flexslider.css?ver=3.93.0' type='text/css' media='all' property='stylesheet' />
+<link rel='stylesheet' id='metaslider-public-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/ml-slider/assets/metaslider/public.css?ver=3.93.0' type='text/css' media='all' property='stylesheet' />
+<style id='metaslider-public-inline-css' type='text/css'>
+@media only screen and (max-width: 767px) {body:after { display: none; content: "smartphone"; } .hide-arrows-smartphone .flex-direction-nav, .hide-navigation-smartphone .flex-control-paging, .hide-navigation-smartphone .flex-control-nav, .hide-navigation-smartphone .filmstrip{ display: none!important; }}@media only screen and (min-width : 768px) and (max-width: 1023px) {body:after { display: none; content: "tablet"; } .hide-arrows-tablet .flex-direction-nav, .hide-navigation-tablet .flex-control-paging, .hide-navigation-tablet .flex-control-nav, .hide-navigation-tablet .filmstrip{ display: none!important; }}@media only screen and (min-width : 1024px) and (max-width: 1439px) {body:after { display: none; content: "laptop"; } .hide-arrows-laptop .flex-direction-nav, .hide-navigation-laptop .flex-control-paging, .hide-navigation-laptop .flex-control-nav, .hide-navigation-laptop .filmstrip{ display: none!important; }}@media only screen and (min-width : 1440px) {body:after { display: none; content: "desktop"; } .hide-arrows-desktop .flex-direction-nav, .hide-navigation-desktop .flex-control-paging, .hide-navigation-desktop .flex-control-nav, .hide-navigation-desktop .filmstrip{ display: none!important; }}
+@media only screen and (max-width: 767px) {body:after { display: none; content: "smartphone"; } .hide-arrows-smartphone .flex-direction-nav, .hide-navigation-smartphone .flex-control-paging, .hide-navigation-smartphone .flex-control-nav, .hide-navigation-smartphone .filmstrip{ display: none!important; }}@media only screen and (min-width : 768px) and (max-width: 1023px) {body:after { display: none; content: "tablet"; } .hide-arrows-tablet .flex-direction-nav, .hide-navigation-tablet .flex-control-paging, .hide-navigation-tablet .flex-control-nav, .hide-navigation-tablet .filmstrip{ display: none!important; }}@media only screen and (min-width : 1024px) and (max-width: 1439px) {body:after { display: none; content: "laptop"; } .hide-arrows-laptop .flex-direction-nav, .hide-navigation-laptop .flex-control-paging, .hide-navigation-laptop .flex-control-nav, .hide-navigation-laptop .filmstrip{ display: none!important; }}@media only screen and (min-width : 1440px) {body:after { display: none; content: "desktop"; } .hide-arrows-desktop .flex-direction-nav, .hide-navigation-desktop .flex-control-paging, .hide-navigation-desktop .flex-control-nav, .hide-navigation-desktop .filmstrip{ display: none!important; }}
+</style>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/embed-any-document/js/pdfobject.min.js?ver=2.7.4' id='awsm-ead-pdf-object-js'></script>
+<script type='text/javascript' id='awsm-ead-public-js-extra'>
+/* <![CDATA[ */
+var eadPublic = [];
+/* ]]> */
+</script>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/embed-any-document/js/embed-public.min.js?ver=2.7.4' id='awsm-ead-public-js'></script>
+<script type='text/javascript' id='scroll-back-to-top-js-extra'>
+/* <![CDATA[ */
+var scrollBackToTop = {"scrollDuration":"500","fadeDuration":"0.5"};
+/* ]]> */
+</script>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/scroll-back-to-top/assets/js/scroll-back-to-top.js' id='scroll-back-to-top-js'></script>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri/js/app.min.js?ver=6.2.8' id='habakiri-js'></script>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/ml-slider/assets/sliders/flexslider/jquery.flexslider.min.js?ver=3.93.0' id='metaslider-flex-slider-js'></script>
+<script type='text/javascript' id='metaslider-flex-slider-js-after'>
+var metaslider_38 = function($) {$('#metaslider_38').addClass('flexslider');
+            $('#metaslider_38').flexslider({ 
+                slideshowSpeed:6000,
+                animation:"fade",
+                controlNav:true,
+                directionNav:true,
+                pauseOnHover:true,
+                direction:"horizontal",
+                reverse:false,
+                keyboard:false,
+                touch:true,
+                animationSpeed:2000,
+                prevText:"Previous",
+                nextText:"Next",
+                smoothHeight:false,
+                fadeFirstSlide:false,
+                slideshow:true,
+                pausePlay:false
+            });
+            $(document).trigger('metaslider/initialized', '#metaslider_38');
+        };
+        var timer_metaslider_38 = function() {
+            var slider = !window.jQuery ? window.setTimeout(timer_metaslider_38, 100) : !jQuery.isReady ? window.setTimeout(timer_metaslider_38, 1) : metaslider_38(window.jQuery);
+        };
+        timer_metaslider_38();
+var metaslider_40 = function($) {$('#metaslider_40').addClass('flexslider');
+            $('#metaslider_40').flexslider({ 
+                slideshowSpeed:6000,
+                animation:"fade",
+                controlNav:false,
+                directionNav:false,
+                pauseOnHover:true,
+                direction:"horizontal",
+                reverse:false,
+                keyboard:false,
+                touch:true,
+                animationSpeed:2000,
+                prevText:"Previous",
+                nextText:"Next",
+                smoothHeight:false,
+                fadeFirstSlide:false,
+                slideshow:true,
+                pausePlay:false
+            });
+            $(document).trigger('metaslider/initialized', '#metaslider_40');
+        };
+        var timer_metaslider_40 = function() {
+            var slider = !window.jQuery ? window.setTimeout(timer_metaslider_40, 100) : !jQuery.isReady ? window.setTimeout(timer_metaslider_40, 1) : metaslider_40(window.jQuery);
+        };
+        timer_metaslider_40();
+</script>
+<script type='text/javascript' id='metaslider-script-js-extra'>
+/* <![CDATA[ */
+var wpData = {"baseUrl":"https:\/\/www.keisatsubyoin.or.jp"};
+var wpData = {"baseUrl":"https:\/\/www.keisatsubyoin.or.jp"};
+/* ]]> */
+</script>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/ml-slider/assets/metaslider/script.min.js?ver=3.93.0' id='metaslider-script-js'></script>
+<div id="footerFloatingMenu">
+<ul>
+<li class="ft-tel"><a href="tel:03-5343-5611"><i class="fas fa-phone-volume fa-lg"></i>Call Us</a></li>
+<!--<li class="ft-web"><a href="#" target="_blank"><i class="far fa-calendar-alt"></i>Online Booking</a></li>-->
+<li class="ft-access"><a href="/access/"><i class="fas fa-map-marker-alt"></i>Access</a></li>
+</ul>
+</div>
+<script type="text/javascript" src="https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri-child-1/js-child/jquery.rwdImageMaps.min.js"></script>
+<script>
+//Accordion
+jQuery(function(){
+ 
+    //.accordion1 paragraphs toggle their sibling ul elements when clicked
+jQuery('.accordion1 p').click(function(){
+ 
+jQuery(this).next('ul').slideToggle();
+ 
+});
+});
+//End accordion
+
+//Image map responsiveness
+jQuery(document).ready(function(e) {
+jQuery('img[usemap]').rwdImageMaps()
+});
+//End image map responsiveness
+jQuery(window).on('load', function() {
+var url = jQuery(location).attr('href');
+if(url.indexOf("#") != -1){
+var anchor = url.split("#");
+var target = jQuery('#' + anchor[anchor.length - 1]);
+if(target.length){
+var pos = Math.floor(target.offset().top) - 180;
+jQuery("html, body").animate({scrollTop:pos}, 300);
+}
+}
+});
+
+</script>
+<script>
+jQuery(function() {
+jQuery('.nav-tab > li').on('click',function(){
+jQuery('.nav-tab > li').removeClass('active')
+jQuery(this).addClass('active')
+var index = jQuery('.nav-tab > li').index(this);
+jQuery('#categoryTab > ul').removeClass('show'); 
+jQuery('#categoryTab > ul').eq(index).addClass('show'); 
+});
+});
+</script>
+
+<script>
+(function() {
+  var map = [
+    {prefix: "/", to: "./index.html"},
+    {prefix: "/profile/", to: "./about.html"},
+    {prefix: "/shinryoka/", to: "./departments.html"},
+    {prefix: "/gairai/", to: "./outpatient.html"},
+    {prefix: "/nyuin/", to: "./inpatient.html"},
+    {prefix: "/support/", to: "./support.html"},
+    {prefix: "/access/", to: "./access.html"}
+  ];
+  function remap(u) {
+    var p = u.pathname || "/";
+    var m = map.slice().sort(function(a, b) {
+      return b.prefix.length - a.prefix.length;
+    }).find(function(x) {
+      return p.indexOf(x.prefix) === 0;
+    });
+    return m ? m.to : null;
+  }
+  document.addEventListener('DOMContentLoaded', function() {
+    document.querySelectorAll('a[href]').forEach(function(a) {
+      try {
+        var u = new URL(a.getAttribute('href'), location.href);
+        if (/(^|\.)keisatsubyoin\.or\.jp$/i.test(u.hostname)) {
+          var to = remap(u);
+          if (to) {
+            a.setAttribute('href', to);
+          }
+        }
+      } catch (e) {}
+    });
+  });
+})();
+</script>
+
+</body>
+</html>

--- a/access.html
+++ b/access.html
@@ -1,0 +1,659 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en" prefix="og: https://ogp.me/ns#">
+<head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# article: http://ogp.me/ns/article#">
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<link rel="shortcut icon" href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2022/12/favicon.png" />
+<link rel="pingback" href="https://www.keisatsubyoin.or.jp/wordpress/xmlrpc.php" />
+<link href="https://use.fontawesome.com/releases/v5.0.10/css/all.css" rel="stylesheet">
+<link rel="stylesheet" href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri-child-1/css/pageheader-style.css" />
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-VTBF3Q2K4B"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-VTBF3Q2K4B');
+</script>
+<!--[if lt IE 9]>
+<script src="https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri/js/html5shiv.min.js"></script>
+<![endif]-->
+<title>Access | Tokyo Metropolitan Police Hospital</title>
+
+<!-- All in One SEO 4.7.6 - aioseo.com -->
+<meta name="description" content="Content coming soon." />
+<meta name="robots" content="max-image-preview:large" />
+<meta name="msvalidate.01" content="6025B7F66D63703BEED4E4073634721A" />
+<link rel="canonical" href="./access.html" />
+<meta name="generator" content="All in One SEO (AIOSEO) 4.7.6" />
+
+<meta name="google-site-verification" content="97tlZIAoAnOmR7w1s9-GNtXfEEnBRDb7DyN4QJ3Lv3s" />
+<meta property="og:locale" content="en_US" />
+<meta property="og:site_name" content="Tokyo Metropolitan Police Hospital | Medical Care That Protects Those You Love | Tokyo Metropolitan Police Hospital in Nakano Ward Welcomes All Community Members" />
+<meta property="og:type" content="website" />
+<meta property="og:title" content="Access | Tokyo Metropolitan Police Hospital" />
+<meta property="og:description" content="Medical care that protects those you love | Tokyo Metropolitan Police Hospital in Nakano Ward welcomes anyone in the community." />
+<meta property="og:url" content="./access.html" />
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content="Access | Tokyo Metropolitan Police Hospital" />
+<meta name="twitter:description" content="Content coming soon." />
+<script type="application/ld+json" class="aioseo-schema">
+{"@context":"https:\/\/schema.org","@graph":[{"@type":"BreadcrumbList","@id":"https:\/\/www.keisatsubyoin.or.jp\/#breadcrumblist","itemListElement":[{"@type":"ListItem","@id":"https:\/\/www.keisatsubyoin.or.jp\/#listItem","position":1,"name":"Home"}]},{"@type":"Organization","@id":"https:\/\/www.keisatsubyoin.or.jp\/#organization","name":"Tokyo Metropolitan Police Hospital","description":"Medical care that protects those you love | Tokyo Metropolitan Police Hospital in Nakano Ward welcomes anyone in the community.","url":"https:\/\/www.keisatsubyoin.or.jp\/"},{"@type":"WebPage","@id":"https:\/\/www.keisatsubyoin.or.jp\/#webpage","url":"https:\/\/www.keisatsubyoin.or.jp\/","name":"Tokyo Metropolitan Police Hospital | Medical Care That Protects Those You Love | Tokyo Metropolitan Police Hospital in Nakano Ward Welcomes All Community Members","description":"Medical care that protects those you love | Tokyo Metropolitan Police Hospital in Nakano Ward welcomes anyone in the community.","inLanguage":"en","isPartOf":{"@id":"https:\/\/www.keisatsubyoin.or.jp\/#website"},"breadcrumb":{"@id":"https:\/\/www.keisatsubyoin.or.jp\/#breadcrumblist"},"datePublished":"2019-12-03T08:15:37+09:00","dateModified":"2025-05-01T10:08:09+09:00"},{"@type":"WebSite","@id":"https:\/\/www.keisatsubyoin.or.jp\/#website","url":"https:\/\/www.keisatsubyoin.or.jp\/","name":"Tokyo Metropolitan Police Hospital","description":"Medical care that protects those you love | Tokyo Metropolitan Police Hospital in Nakano Ward welcomes anyone in the community.","inLanguage":"en","publisher":{"@id":"https:\/\/www.keisatsubyoin.or.jp\/#organization"},"potentialAction":{"@type":"SearchAction","target":{"@type":"EntryPoint","urlTemplate":"https:\/\/www.keisatsubyoin.or.jp\/?s={search_term_string}"},"query-input":"required name=search_term_string"}}]}
+</script>
+<!-- All in One SEO -->
+
+<link rel='dns-prefetch' href='//netdna.bootstrapcdn.com' />
+<link rel="alternate" type="application/rss+xml" title="Tokyo Metropolitan Police Hospital &raquo; Feed" href="https://www.keisatsubyoin.or.jp/feed/" />
+<script type="text/javascript">
+window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/14.0.0\/72x72\/","ext":".png","svgUrl":"https:\/\/s.w.org\/images\/core\/emoji\/14.0.0\/svg\/","svgExt":".svg","source":{"concatemoji":"https:\/\/www.keisatsubyoin.or.jp\/wordpress\/wp-includes\/js\/wp-emoji-release.min.js?ver=6.2.8"}};
+/*! This file is auto-generated */
+!function(e,a,t){var n,r,o,i=a.createElement("canvas"),p=i.getContext&&i.getContext("2d");function s(e,t){p.clearRect(0,0,i.width,i.height),p.fillText(e,0,0);e=i.toDataURL();return p.clearRect(0,0,i.width,i.height),p.fillText(t,0,0),e===i.toDataURL()}function c(e){var t=a.createElement("script");t.src=e,t.defer=t.type="text/javascript",a.getElementsByTagName("head")[0].appendChild(t)}for(o=Array("flag","emoji"),t.supports={everything:!0,everythingExceptFlag:!0},r=0;r<o.length;r++)t.supports[o[r]]=function(e){if(p&&p.fillText)switch(p.textBaseline="top",p.font="600 32px Arial",e){case"flag":return s("\ud83c\udff3\ufe0f\u200d\u26a7\ufe0f","\ud83c\udff3\ufe0f\u200b\u26a7\ufe0f")?!1:!s("\ud83c\uddfa\ud83c\uddf3","\ud83c\uddfa\u200b\ud83c\uddf3")&&!s("\ud83c\udff4\udb40\udc67\udb40\udc62\udb40\udc65\udb40\udc6e\udb40\udc67\udb40\udc7f","\ud83c\udff4\u200b\udb40\udc67\u200b\udb40\udc62\u200b\udb40\udc65\u200b\udb40\udc6e\u200b\udb40\udc67\u200b\udb40\udc7f");case"emoji":return!s("\ud83e\udef1\ud83c\udffb\u200d\ud83e\udef2\ud83c\udfff","\ud83e\udef1\ud83c\udffb\u200b\ud83e\udef2\ud83c\udfff")}return!1}(o[r]),t.supports.everything=t.supports.everything&&t.supports[o[r]],"flag"!==o[r]&&(t.supports.everythingExceptFlag=t.supports.everythingExceptFlag&&t.supports[o[r]]);t.supports_everythingExceptFlag=t.supports.everythingExceptFlag&&!t.supports.flag,t.DOMReady=!1,t.readyCallback=function(){t.DOMReady=!0},t.supports.everything||(n=function(){t.readyCallback()},a.addEventListener?(a.addEventListener("DOMContentLoaded",n,!1),e.addEventListener("load",n,!1)):(e.attachEvent("onload",n),a.attachEvent("onreadystatechange",function(){"complete"===a.readyState&&t.readyCallback()})),(e=t.source||{}).concatemoji?c(e.concatemoji):e.wpemoji&&e.twemoji&&(c(e.twemoji),c(e.wpemoji)))}(window,document,window._wpemojiSettings);
+</script>
+<style type="text/css">
+img.wp-smiley,
+img.emoji {
+display: inline !important;
+border: none !important;
+box-shadow: none !important;
+height: 1em !important;
+width: 1em !important;
+margin: 0 0.07em !important;
+vertical-align: -0.1em !important;
+background: none !important;
+padding: 0 !important;
+}
+</style>
+<link rel='stylesheet' id='wp-block-library-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-includes/css/dist/block-library/style.min.css?ver=6.2.8' type='text/css' media='all' />
+<style id='pdfemb-pdf-embedder-viewer-style-inline-css' type='text/css'>
+.wp-block-pdfemb-pdf-embedder-viewer{max-width:none}
+
+</style>
+<link rel='stylesheet' id='awsm-ead-public-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/embed-any-document/css/embed-public.min.css?ver=2.7.4' type='text/css' media='all' />
+<link rel='stylesheet' id='classic-theme-styles-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-includes/css/classic-themes.min.css?ver=6.2.8' type='text/css' media='all' />
+<style id='global-styles-inline-css' type='text/css'>
+body{
+--wp--preset--color--black: #000000;
+--wp--preset--color--cyan-bluish-gray: #abb8c3;
+--wp--preset--color--white: #ffffff;
+--wp--preset--color--pale-pink: #f78da7;
+--wp--preset--color--vivid-red: #cf2e2e;
+--wp--preset--color--luminous-vivid-orange: #ff6900;
+--wp--preset--color--luminous-vivid-amber: #fcb900;
+--wp--preset--color--light-green-cyan: #7bdcb5;
+--wp--preset--color--vivid-green-cyan: #00d084;
+--wp--preset--color--pale-cyan-blue: #8ed1fc;
+--wp--preset--color--vivid-cyan-blue: #0693e3;
+--wp--preset--color--vivid-purple: #9b51e0;
+--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%);
+--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan: linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%);
+--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange: linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%);
+--wp--preset--gradient--luminous-vivid-orange-to-vivid-red: linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%);
+--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray: linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%);
+--wp--preset--gradient--cool-to-warm-spectrum: linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186) 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%);
+--wp--preset--gradient--blush-light-purple: linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%);
+--wp--preset--gradient--blush-bordeaux: linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%);
+--wp--preset--gradient--luminous-dusk: linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%);
+--wp--preset--gradient--pale-ocean: linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181) 100%);
+--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128) 0%,rgb(113,206,126) 100%);
+--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%);
+--wp--preset--duotone--dark-grayscale: url('#wp-duotone-dark-grayscale');
+--wp--preset--duotone--grayscale: url('#wp-duotone-grayscale');
+--wp--preset--duotone--purple-yellow: url('#wp-duotone-purple-yellow');
+--wp--preset--duotone--blue-red: url('#wp-duotone-blue-red');
+--wp--preset--duotone--midnight: url('#wp-duotone-midnight');
+--wp--preset--duotone--magenta-yellow: url('#wp-duotone-magenta-yellow');
+--wp--preset--duotone--purple-green: url('#wp-duotone-purple-green');
+--wp--preset--duotone--blue-orange: url('#wp-duotone-blue-orange');
+--wp--preset--font-size--small: 13px;
+--wp--preset--font-size--medium: 20px;
+--wp--preset--font-size--large: 36px;
+--wp--preset--font-size--x-large: 42px;
+--wp--preset--spacing--20: 0.44rem;
+--wp--preset--spacing--30: 0.67rem;
+--wp--preset--spacing--40: 1rem;
+--wp--preset--spacing--50: 1.5rem;
+--wp--preset--spacing--60: 2.25rem;
+--wp--preset--spacing--70: 3.38rem;
+--wp--preset--spacing--80: 5.06rem;
+--wp--preset--shadow--natural: 6px 6px 9px rgba(0, 0, 0, 0.2);
+--wp--preset--shadow--deep: 12px 12px 50px rgba(0, 0, 0, 0.4);
+--wp--preset--shadow--sharp: 6px 6px 0px rgba(0, 0, 0, 0.2);
+--wp--preset--shadow--outlined: 6px 6px 0px -3px rgba(255, 255, 255, 1), 6px 6px rgba(0, 0, 0, 1);
+--wp--preset--shadow--crisp: 6px 6px 0px rgba(0, 0, 0, 1);
+}
+:where(.is-layout-flex){gap: 0.5em;}
+body .is-layout-flow > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}
+body .is-layout-flow > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}
+body .is-layout-flow > .aligncenter{margin-left: auto !important;margin-right: auto !important;}
+body .is-layout-constrained > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}
+body .is-layout-constrained > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}
+body .is-layout-constrained > .aligncenter{margin-left: auto !important;margin-right: auto !important;}
+body .is-layout-constrained > :where(:not(.alignleft):not(.alignright):not(.alignfull)){max-width: var(--wp--style--global--content-size);margin-left: auto !important;margin-right: auto !important;}
+body .is-layout-constrained > .alignwide{max-width: var(--wp--style--global--wide-size);}
+body .is-layout-flex{display: flex;}
+body .is-layout-flex{flex-wrap: wrap;align-items: center;}
+body .is-layout-flex > *{margin: 0;}
+:where(.wp-block-columns.is-layout-flex){gap: 2em;}
+.has-black-color{color: var(--wp--preset--color--black) !important;}
+.has-cyan-bluish-gray-color{color: var(--wp--preset--color--cyan-bluish-gray) !important;}
+.has-white-color{color: var(--wp--preset--color--white) !important;}
+.has-pale-pink-color{color: var(--wp--preset--color--pale-pink) !important;}
+.has-vivid-red-color{color: var(--wp--preset--color--vivid-red) !important;}
+.has-luminous-vivid-orange-color{color: var(--wp--preset--color--luminous-vivid-orange) !important;}
+.has-luminous-vivid-amber-color{color: var(--wp--preset--color--luminous-vivid-amber) !important;}
+.has-light-green-cyan-color{color: var(--wp--preset--color--light-green-cyan) !important;}
+.has-vivid-green-cyan-color{color: var(--wp--preset--color--vivid-green-cyan) !important;}
+.has-pale-cyan-blue-color{color: var(--wp--preset--color--pale-cyan-blue) !important;}
+.has-vivid-cyan-blue-color{color: var(--wp--preset--color--vivid-cyan-blue) !important;}
+.has-vivid-purple-color{color: var(--wp--preset--color--vivid-purple) !important;}
+.has-black-background-color{background-color: var(--wp--preset--color--black) !important;}
+.has-cyan-bluish-gray-background-color{background-color: var(--wp--preset--color--cyan-bluish-gray) !important;}
+.has-white-background-color{background-color: var(--wp--preset--color--white) !important;}
+.has-pale-pink-background-color{background-color: var(--wp--preset--color--pale-pink) !important;}
+.has-vivid-red-background-color{background-color: var(--wp--preset--color--vivid-red) !important;}
+.has-luminous-vivid-orange-background-color{background-color: var(--wp--preset--color--luminous-vivid-orange) !important;}
+.has-luminous-vivid-amber-background-color{background-color: var(--wp--preset--color--luminous-vivid-amber) !important;}
+.has-light-green-cyan-background-color{background-color: var(--wp--preset--color--light-green-cyan) !important;}
+.has-vivid-green-cyan-background-color{background-color: var(--wp--preset--color--vivid-green-cyan) !important;}
+.has-pale-cyan-blue-background-color{background-color: var(--wp--preset--color--pale-cyan-blue) !important;}
+.has-vivid-cyan-blue-background-color{background-color: var(--wp--preset--color--vivid-cyan-blue) !important;}
+.has-vivid-purple-background-color{background-color: var(--wp--preset--color--vivid-purple) !important;}
+.has-black-border-color{border-color: var(--wp--preset--color--black) !important;}
+.has-cyan-bluish-gray-border-color{border-color: var(--wp--preset--color--cyan-bluish-gray) !important;}
+.has-white-border-color{border-color: var(--wp--preset--color--white) !important;}
+.has-pale-pink-border-color{border-color: var(--wp--preset--color--pale-pink) !important;}
+.has-vivid-red-border-color{border-color: var(--wp--preset--color--vivid-red) !important;}
+.has-luminous-vivid-orange-border-color{border-color: var(--wp--preset--color--luminous-vivid-orange) !important;}
+.has-luminous-vivid-amber-border-color{border-color: var(--wp--preset--color--luminous-vivid-amber) !important;}
+.has-light-green-cyan-border-color{border-color: var(--wp--preset--color--light-green-cyan) !important;}
+.has-vivid-green-cyan-border-color{border-color: var(--wp--preset--color--vivid-green-cyan) !important;}
+.has-pale-cyan-blue-border-color{border-color: var(--wp--preset--color--pale-cyan-blue) !important;}
+.has-vivid-cyan-blue-border-color{border-color: var(--wp--preset--color--vivid-cyan-blue) !important;}
+.has-vivid-purple-border-color{border-color: var(--wp--preset--color--vivid-purple) !important;}
+.has-vivid-cyan-blue-to-vivid-purple-gradient-background{background: var(--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple) !important;}
+.has-light-green-cyan-to-vivid-green-cyan-gradient-background{background: var(--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan) !important;}
+.has-luminous-vivid-amber-to-luminous-vivid-orange-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange) !important;}
+.has-luminous-vivid-orange-to-vivid-red-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-orange-to-vivid-red) !important;}
+.has-very-light-gray-to-cyan-bluish-gray-gradient-background{background: var(--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray) !important;}
+.has-cool-to-warm-spectrum-gradient-background{background: var(--wp--preset--gradient--cool-to-warm-spectrum) !important;}
+.has-blush-light-purple-gradient-background{background: var(--wp--preset--gradient--blush-light-purple) !important;}
+.has-blush-bordeaux-gradient-background{background: var(--wp--preset--gradient--blush-bordeaux) !important;}
+.has-luminous-dusk-gradient-background{background: var(--wp--preset--gradient--luminous-dusk) !important;}
+.has-pale-ocean-gradient-background{background: var(--wp--preset--gradient--pale-ocean) !important;}
+.has-electric-grass-gradient-background{background: var(--wp--preset--gradient--electric-grass) !important;}
+.has-midnight-gradient-background{background: var(--wp--preset--gradient--midnight) !important;}
+.has-small-font-size{font-size: var(--wp--preset--font-size--small) !important;}
+.has-medium-font-size{font-size: var(--wp--preset--font-size--medium) !important;}
+.has-large-font-size{font-size: var(--wp--preset--font-size--large) !important;}
+.has-x-large-font-size{font-size: var(--wp--preset--font-size--x-large) !important;}
+.wp-block-navigation a:where(:not(.wp-element-button)){color: inherit;}
+:where(.wp-block-columns.is-layout-flex){gap: 2em;}
+.wp-block-pullquote{font-size: 1.5em;line-height: 1.6;}
+</style>
+<link rel='stylesheet' id='font-awesome-css' href='//netdna.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.css' type='text/css' media='screen' />
+<link rel='stylesheet' id='habakiri-assets-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri/css/assets.min.css?ver=6.2.8' type='text/css' media='all' />
+<link rel='stylesheet' id='habakiri-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri/style.min.css?ver=20250926050751' type='text/css' media='all' />
+<link rel='stylesheet' id='habakiri-child-1-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri-child-1/style.css?ver=20250926050751' type='text/css' media='all' />
+<link rel='stylesheet' id='msl-main-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/master-slider/public/assets/css/masterslider.main.css?ver=3.10.0' type='text/css' media='all' />
+<link rel='stylesheet' id='msl-custom-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/master-slider/custom.css?ver=4.5' type='text/css' media='all' />
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-includes/js/jquery/jquery.min.js?ver=3.6.4' id='jquery-core-js'></script>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-includes/js/jquery/jquery-migrate.min.js?ver=3.4.0' id='jquery-migrate-js'></script>
+<link rel="https://api.w.org/" href="https://www.keisatsubyoin.or.jp/wp-json/" /><link rel="alternate" type="application/json" href="https://www.keisatsubyoin.or.jp/wp-json/wp/v2/pages/22" /><link rel="EditURI" type="application/rsd+xml" title="RSD" href="https://www.keisatsubyoin.or.jp/wordpress/xmlrpc.php?rsd" />
+<link rel="wlwmanifest" type="application/wlwmanifest+xml" href="https://www.keisatsubyoin.or.jp/wordpress/wp-includes/wlwmanifest.xml" />
+<meta name="generator" content="WordPress 6.2.8" />
+<link rel='shortlink' href='https://www.keisatsubyoin.or.jp/' />
+<link rel="alternate" type="application/json+oembed" href="https://www.keisatsubyoin.or.jp/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.keisatsubyoin.or.jp%2F" />
+<link rel="alternate" type="text/xml+oembed" href="https://www.keisatsubyoin.or.jp/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.keisatsubyoin.or.jp%2F&#038;format=xml" />
+<script>var ms_grabbing_curosr = 'https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/master-slider/public/assets/css/common/grabbing.cur', ms_grab_curosr = 'https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/master-slider/public/assets/css/common/grab.cur';</script>
+<meta name="generator" content="MasterSlider 3.10.0 - Responsive Touch Image Slider | avt.li/msf" />
+
+<style>
+.scroll-back-to-top-wrapper {
+    position: fixed;
+opacity: 0;
+visibility: hidden;
+overflow: hidden;
+text-align: center;
+z-index: 99999999;
+    background-color: #777777;
+color: #eeeeee;
+width: 50px;
+height: 48px;
+line-height: 48px;
+right: 30px;
+bottom: 60px;
+padding-top: 2px;
+border-top-left-radius: 10px;
+border-top-right-radius: 10px;
+border-bottom-right-radius: 10px;
+border-bottom-left-radius: 10px;
+-webkit-transition: all 0.5s ease-in-out;
+-moz-transition: all 0.5s ease-in-out;
+-ms-transition: all 0.5s ease-in-out;
+-o-transition: all 0.5s ease-in-out;
+transition: all 0.5s ease-in-out;
+}
+.scroll-back-to-top-wrapper:hover {
+background-color: #888888;
+  color: #eeeeee;
+}
+.scroll-back-to-top-wrapper.show {
+    visibility:visible;
+    cursor:pointer;
+opacity: 1.0;
+}
+.scroll-back-to-top-wrapper i.fa {
+line-height: inherit;
+}
+.scroll-back-to-top-wrapper .fa-lg {
+vertical-align: 0;
+}
+</style><style>
+/* Safari 6.1+ (10.0 is the latest version of Safari at this time) */
+@media (max-width: 991px) and (min-color-index: 0) and (-webkit-min-device-pixel-ratio: 0) { @media () {
+display: block !important;
+.header__col {
+width: 100%;
+}
+}}
+</style>
+<style>a{color:#337ab7}a:focus,a:active,a:hover{color:#23527c}.site-branding a{color:#000}.responsive-nav a{color:#ffffff;font-size:14px}.responsive-nav a small{color:#707070;font-size:10px}.responsive-nav a:hover small,.responsive-nav a:active small,.responsive-nav .current-menu-item small,.responsive-nav .current-menu-ancestor small,.responsive-nav .current-menu-parent small,.responsive-nav .current_page_item small,.responsive-nav .current_page_parent small{color:#707070}.responsive-nav .menu>.menu-item>a,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.menu-item>a{background-color:#f4a000;padding:12px 7px}.responsive-nav .menu>.menu-item>a:hover,.responsive-nav .menu>.menu-item>a:active,.responsive-nav .menu>.current-menu-item>a,.responsive-nav .menu>.current-menu-ancestor>a,.responsive-nav .menu>.current-menu-parent>a,.responsive-nav .menu>.current_page_item>a,.responsive-nav .menu>.current_page_parent>a,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.menu-item>a:hover,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.menu-item>a:active,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.current-menu-item>a,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.current-menu-ancestor>a,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.current-menu-parent>a,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.current_page_item>a,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.current_page_parent>a{background-color:#f5f5f5;color:#707070}.responsive-nav .sub-menu a{background-color:#f5f5f5;color:#707070}.responsive-nav .sub-menu a:hover,.responsive-nav .sub-menu a:active,.responsive-nav .sub-menu .current-menu-item a,.responsive-nav .sub-menu .current-menu-ancestor a,.responsive-nav .sub-menu .current-menu-parent a,.responsive-nav .sub-menu .current_page_item a,.responsive-nav .sub-menu .current_page_parent a{background-color:#f5f5f5;color:#707070}.off-canvas-nav{font-size:12px}.responsive-nav,.header--transparency.header--fixed--is_scrolled .responsive-nav{background-color:#f4a000}#responsive-btn{background-color:transparent;border-color:#eeeeee;color:#000}#responsive-btn:hover{background-color:#f5f5f5;border-color:#eee;color:#000}.habakiri-slider__transparent-layer{background-color:rgba( 0,0,0, 0.1 )}.page-header{background-color:#dddddd;color:#fff}.pagination>li>a{color:#337ab7}.pagination>li>span{background-color:#337ab7;border-color:#337ab7}.pagination>li>a:focus,.pagination>li>a:hover,.pagination>li>span:focus,.pagination>li>span:hover{color:#23527c}.header{background-color:#fff}.header--transparency.header--fixed--is_scrolled{background-color:#fff !important}.footer{background-color:#f49000}.footer-widget-area a{color:#777}.footer-widget-area,.footer-widget-area .widget_calendar #wp-calendar caption{color:#555}.footer-widget-area .widget_calendar #wp-calendar,.footer-widget-area .widget_calendar #wp-calendar *{border-color:#555}@media(min-width:992px){.responsive-nav{display:block}.off-canvas-nav,#responsive-btn{display:none !important}.header--2row{padding-bottom:0}.header--2row .header__col,.header--center .header__col{display:block}.header--2row .responsive-nav,.header--center .responsive-nav{margin-right:-1000px;margin-left:-1000px;padding-right:1000px;padding-left:1000px}.header--center .site-branding{text-align:center}}</style><link rel="icon" href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2022/12/favicon.png" sizes="32x32" />
+<link rel="icon" href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2022/12/favicon.png" sizes="192x192" />
+<link rel="apple-touch-icon" href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2022/12/favicon.png" />
+<meta name="msapplication-TileImage" content="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2022/12/favicon.png" />
+<style type="text/css" id="wp-custom-css">
+.cl_rd {
+color: #F00;
+}
+.responsive-nav .sub-menu a {
+background-color: #f5f5f5;
+color: #707070;
+font-weight:bold
+}
+body{
+  word-wrap : break-word;
+  overflow-wrap : break-word;
+}
+
+img {
+    -webkit-backface-visibility: hidden;
+}
+@media print {
+.scroll-back-to-top-wrapper{
+display: none !important;
+}
+}
+
+.spmenu2 {
+             padding:  10px 0 0;
+    }
+@media screen and (max-width: 991px) {
+    .spmenu {
+       /* border-bottom: solid 1px #ffcf74;*/
+        padding:  0 0 10px;
+width: 100%;
+    }
+}</style>
+</head>
+<body data-rsssl=1 class="home page-template page-template-templates page-template-rich-front-page page-template-templatesrich-front-page-php page page-id-22 _masterslider _ms_version_3.10.0">
+<div id="container">
+<header id="header" class="header header--2row ">
+<div class="container">
+<div class="row header__content">
+<div class="col-xs-10 col-md-12 header__col">
+<div class ="row">
+<div class="col-md-6 col-sm-12">
+
+<div class="site-branding">
+<h1 class="site-branding__heading">
+<a href="./index.html" rel="home"><img src="https://keisatsubyoin.or.jp/wordpress/wp-content/uploads/2020/03/logo.png" alt="Tokyo Metropolitan Police Hospital" class="site-branding__logo" /></a></h1>
+<!-- end .site-branding --></div>
+                        </div>
+<div class="col-md-6 col-sm-12 h-btn-flex">
+<div id="site-cr">
+<a href="./index.html" class="h-btn current">Website for Patients</a>
+<a href="https://www.keisatsubyoin.or.jp/m/" class="h-btn">Website for Healthcare Professionals</a>
+</div>
+                        <ul class="topnav2">
+<li class="f-cv-tel"><i class="fas fa-phone-volume"></i>03-5343-5611<span style="font-size:12px"> (Main)</span><!--<span class="h-time">【Reception Hours】8:00~11:30/12:30~16:00</span>--></li>
+</ul>
+                        </div>
+                 </div>
+         <!-- end .header__col --></div>
+<div class="col-xs-2 col-md-12 header__col global-nav-wrapper clearfix">
+
+<nav class="global-nav js-responsive-nav nav--hide" role="navigation">
+<div class="menu-gnavi-container"><ul id="menu-gnavi" class="menu"><li id="menu-item-35" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-35"><a href="./index.html"><div class="m-icon"><i class="fas fa-home"></i>Home</div></a></li>
+<li id="menu-item-157" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-157"><a href="./outpatient.html"><div class="m-icon"><i class="fas fa-stethoscope"></i>Outpatient Visits</div></a>
+<ul class="sub-menu">
+<li id="menu-item-170" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-170"><a href="./outpatient.html">For First-Time Patients</a></li>
+<li id="menu-item-172" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-172"><a href="./outpatient.html">For Returning Patients</a></li>
+<li id="menu-item-12181" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-12181"><a href="./outpatient.html">About Nighttime &amp; Holiday Clinics</a></li>
+<li id="menu-item-171" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-171"><a href="./outpatient.html">For Patients with Referral Letters</a></li>
+<li id="menu-item-10898" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-10898"><a href="./outpatient.html">About Focused Referral Medical Institutions</a></li>
+<li id="menu-item-169" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-169"><a href="./outpatient.html">Community Primary Care Physicians</a></li>
+<li id="menu-item-158" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-158"><a href="./outpatient.html">About Medications</a></li>
+</ul>
+</li>
+<li id="menu-item-32" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-32"><a href="./departments.html"><div class="m-icon"><i class="fas fa-syringe"></i>Departments &amp; Divisions</div></a></li>
+<li id="menu-item-190" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-190"><a href="./inpatient.html"><div class="m-icon"><i class="fas fa-bed"></i>Inpatient Guide</div></a>
+<ul class="sub-menu">
+<li id="menu-item-194" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-194"><a href="./inpatient.html">Admission &amp; Discharge</a></li>
+<li id="menu-item-191" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-191"><a href="./inpatient.html">For Visitors</a></li>
+<li id="menu-item-193" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-193"><a href="./inpatient.html">Life During Hospitalization</a></li>
+<li id="menu-item-196" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-196"><a href="./inpatient.html">About Patient Rooms</a></li>
+<li id="menu-item-192" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-192"><a href="./inpatient.html">Messages to Inpatients</a></li>
+<li id="menu-item-195" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-195"><a href="./inpatient.html">About DPC</a></li>
+</ul>
+</li>
+<li id="menu-item-332" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-332"><a href="./about.html"><div class="m-icon"><i class="fas fa-hospital-alt"></i>About the Hospital</div></a>
+<ul class="sub-menu">
+<li id="menu-item-330" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-330"><a href="./about.html">Message from the Hospital Director</a></li>
+<li id="menu-item-338" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-338"><a href="./about.html">Overview &amp; History</a></li>
+<li id="menu-item-318" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-318"><a href="./about.html">Philosophy &amp; Core Policies</a></li>
+<li id="menu-item-5336" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-5336"><a href="./about.html">Policy on Refusal of Blood Transfusions</a></li>
+<li id="menu-item-317" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-317"><a href="./about.html">Patients' Rights &amp; Responsibilities</a></li>
+<li id="menu-item-7761" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-7761"><a href="./about.html">Request for Comprehensive Consent</a></li>
+<li id="menu-item-319" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-319"><a href="./about.html">Partnership with Patients</a></li>
+<li id="menu-item-329" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-329"><a href="./about.html">Facility Guide</a></li>
+<li id="menu-item-321" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-321"><a href="./about.html">Professional Accreditations</a></li>
+<li id="menu-item-322" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-322"><a href="./about.html">Advanced Medical Equipment</a></li>
+<li id="menu-item-323" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-323"><a href="./about.html">Accredited Hospital Functions</a></li>
+<li id="menu-item-325" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-325"><a href="./about.html">Tokyo Police Hospital by the Numbers</a></li>
+<li id="menu-item-4097" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4097"><a href="https://www.keisatsubyoin.or.jp/privacy/">Privacy Policy</a></li>
+<li id="menu-item-4098" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4098"><a href="https://www.keisatsubyoin.or.jp/nextgeneration/">Next Generation Development Support Measures</a></li>
+<li id="menu-item-4099" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4099"><a href="https://www.keisatsubyoin.or.jp/josei/">Women's Advancement Promotion Plan</a></li>
+<li id="menu-item-4197" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4197"><a href="./about.html">Notices Required by the Minister of Health, Labour and Welfare</a></li>
+</ul>
+</li>
+<li id="menu-item-357" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-357"><a href="./support.html"><div class="m-icon"><i class="fas fa-comment-dots"></i>Consultation &amp; Support</div></a>
+<ul class="sub-menu">
+<li id="menu-item-364" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-364"><a href="./support.html">Information Desk</a></li>
+<li id="menu-item-365" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-365"><a href="./support.html">About Second Opinions</a></li>
+<li id="menu-item-362" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-362"><a href="./support.html">Nutrition Counseling &amp; Guidance</a></li>
+<li id="menu-item-361" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-361"><a href="./support.html">Medical Social Services</a></li>
+<li id="menu-item-359" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-359"><a href="./support.html">Access to Medical Records</a></li>
+<li id="menu-item-358" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-358"><a href="./support.html">Clinical Support Team</a></li>
+<li id="menu-item-360" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-360"><a href="./support.html">Frequently Asked Questions</a></li>
+<li id="menu-item-363" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-363"><a href="./support.html">Patient Safety</a></li>
+<li id="menu-item-1573" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1573"><a href="./support.html">Telephone Use</a></li>
+<li id="menu-item-4209" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4209"><a href="./support.html">Suggestion Box</a></li>
+<li id="menu-item-1577" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-1577"><a href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2023/03/患者さま図書コーナーのご案内.pdf">Patient Library Corner</a></li>
+<li id="menu-item-4100" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4100"><a href="https://www.keisatsubyoin.or.jp/news_090821_dog/">Assistance Dogs for Persons with Disabilities</a></li>
+<li id="menu-item-4101" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4101"><a href="https://www.keisatsubyoin.or.jp/research/">Clinical Trials &amp; Research</a></li>
+</ul>
+</li>
+<li id="menu-item-31" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-31"><a href="./access.html"><div class="m-icon"><i class="fas fa-map-marker-alt"></i>Access</div></a></li>
+</ul></div><!-- end .global-nav --></nav>
+<div id="responsive-btn"></div>
+</div>
+<!-- end .header__col --></div>
+<!-- end .container --></div>
+<!-- end #header --></header>
+<div id="contents">
+  <main class="container" role="main">
+    <h1>Access & Directions</h1>
+    <p>Content coming soon.</p>
+  </main>
+<!-- end #contents --></div>
+<footer id="footer" class="footer">
+
+
+<div class="f-menuArea">
+<div class="container">
+<ul class="f-menu">
+<li>
+<div class="spmenu"><i class="fas fa-chevron-right"></i><a href="./outpatient.html">Outpatient Visits</a></div>
+<ul class="f-sub-menu">
+<li><a href="./outpatient.html">For First-Time Patients</a></li>
+<li><a href="./outpatient.html">For Returning Patients</a></li>
+<li><a href="./outpatient.html">Nighttime &amp; Holiday (After-Hours) Clinics</a></li>
+<li><a href="./outpatient.html">For Patients with Referral Letters</a></li>
+<li><a href="./outpatient.html">About Focused Referral Medical Institutions</a></li>
+<li><a href="./outpatient.html">Keep a Community Primary Care Physician</a></li>
+<li><a href="./outpatient.html">About Medications</a></li>
+</ul>
+<div class="spmenu2"><i class="fas fa-chevron-right"></i><a href="./departments.html">Departments &amp; Divisions</a></div>
+</li>
+<li><i class="fas fa-chevron-right"></i><a href="./inpatient.html">Inpatient Guide</a>
+<ul class="f-sub-menu">
+<li><a href="./inpatient.html">About Admission &amp; Discharge</a></li>
+<li><a href="./inpatient.html">For Visitors</a></li>
+<li><a href="./inpatient.html">Life During Hospitalization</a></li>
+<li><a href="./inpatient.html">About Patient Rooms</a></li>
+<li><a href="./inpatient.html">About Messages to Patients</a></li>
+<li><a href="./inpatient.html">About DPC</a></li>
+</ul>
+</li>
+<li><i class="fas fa-chevron-right"></i><a href="./about.html">About the Hospital</a>
+<ul class="f-sub-menu">
+<li><a href="./about.html">Message from the Hospital Director</a></li>
+<li><a href="./about.html">Hospital Overview</a></li>
+<li><a href="./about.html">Philosophy / Core Policies</a></li>
+<li><a href="./about.html">Policy on Refusal of Blood Transfusions</a></li>
+<li><a href="./about.html">Patients' Rights &amp; Responsibilities</a></li>
+<li><a href="./about.html">Request for Comprehensive Consent</a></li>
+<li><a href="./about.html">Partnership with Patients</a></li>
+<!--<li><a href="./about.html">Organization / Committees</a></li>-->
+<li><a href="./about.html">Floor Guide / On-Site Services</a></li>
+<li><a href="./about.html">Professional Accreditations</a></li>
+<li><a href="./about.html">Advanced Medical Equipment</a></li>
+<li><a href="./about.html">Hospital Function Accreditation</a></li>
+<li><a href="./about.html">Tokyo Police Hospital by the Numbers (Clinical Indicators)</a></li>
+<!--<li><a href="./about.html">History</a></li>-->
+<li><a href="https://www.keisatsubyoin.or.jp/privacy/">Privacy Policy</a></li>
+<li><a href="https://www.keisatsubyoin.or.jp/nextgeneration/">Next Generation Development Support Measures</a></li>
+<li><a href="https://www.keisatsubyoin.or.jp/josei/">Women's Advancement Promotion Plan</a></li>
+<li><a href="./about.html">Notices Required by the Minister of Health, Labour and Welfare</a></li>
+<li><a href="https://www.keisatsubyoin.or.jp/sitemap/">Site Map</a></li>
+</ul>
+</li>
+<li><div class="spmenu"><i class="fas fa-chevron-right"></i><a href="./support.html">Consultation &amp; Support</a></div>
+<ul class="f-sub-menu">
+<li><a href="./support.html">Information Desk</a></li>
+<li><a href="./support.html">Second Opinions</a></li>
+<li><a href="./support.html">Meals &amp; Nutrition Guidance</a></li>
+<li><a href="./support.html">Medical Social Services</a></li>
+<li><a href="./support.html">Access to Medical Records</a></li>
+<li><a href="./support.html">Clinical Support</a></li>
+<li><a href="./support.html">Frequently Asked Questions</a></li>
+<li><a href="./support.html">Patient Safety &amp; Infection Control</a></li>
+<li><a href="./support.html">Telephone Use</a></li>
+<li><a href="./support.html">Suggestion Box</a></li>
+<li><a href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2023/03/患者さま図書コーナーのご案内.pdf">Patient Library Corner</a></li>
+<!--<li><a href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2020/02/vol.11_Kanjasama-Tosyo.pdf#page=1&zoom=200">Patient Library Corner</a></li>-->
+<li><a href="https://www.keisatsubyoin.or.jp/news_090821_dog/">Assistance Dogs for Persons with Disabilities</a></li>
+<li><a href="https://www.keisatsubyoin.or.jp/research/">Clinical Trials &amp; Research</a></li>
+</ul>
+<div class="spmenu2"><i class="fas fa-chevron-right"></i><a href="./access.html">Access</a></div>
+</li>
+</ul>
+</div>
+</div>
+<div class="copyright">
+<div class="container">
+&copy; Tokyo Metropolitan Police Hospital 4-22-1 Nakano, Nakano-ku, Tokyo
+<!-- end .container --></div>
+<!-- end .copyright --></div>
+<!-- end #footer --></footer>
+<!-- end #container --></div>
+<div class="scroll-back-to-top-wrapper">
+<span class="scroll-back-to-top-inner">
+<i class="fa fa-2x fa-arrow-circle-up"></i>
+</span>
+</div><script>
+jQuery( function( $ ) {
+$( '.js-responsive-nav' ).responsive_nav( {
+direction: 'right'
+} );
+} );
+</script>
+<link rel='stylesheet' id='metaslider-flex-slider-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/ml-slider/assets/sliders/flexslider/flexslider.css?ver=3.93.0' type='text/css' media='all' property='stylesheet' />
+<link rel='stylesheet' id='metaslider-public-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/ml-slider/assets/metaslider/public.css?ver=3.93.0' type='text/css' media='all' property='stylesheet' />
+<style id='metaslider-public-inline-css' type='text/css'>
+@media only screen and (max-width: 767px) {body:after { display: none; content: "smartphone"; } .hide-arrows-smartphone .flex-direction-nav, .hide-navigation-smartphone .flex-control-paging, .hide-navigation-smartphone .flex-control-nav, .hide-navigation-smartphone .filmstrip{ display: none!important; }}@media only screen and (min-width : 768px) and (max-width: 1023px) {body:after { display: none; content: "tablet"; } .hide-arrows-tablet .flex-direction-nav, .hide-navigation-tablet .flex-control-paging, .hide-navigation-tablet .flex-control-nav, .hide-navigation-tablet .filmstrip{ display: none!important; }}@media only screen and (min-width : 1024px) and (max-width: 1439px) {body:after { display: none; content: "laptop"; } .hide-arrows-laptop .flex-direction-nav, .hide-navigation-laptop .flex-control-paging, .hide-navigation-laptop .flex-control-nav, .hide-navigation-laptop .filmstrip{ display: none!important; }}@media only screen and (min-width : 1440px) {body:after { display: none; content: "desktop"; } .hide-arrows-desktop .flex-direction-nav, .hide-navigation-desktop .flex-control-paging, .hide-navigation-desktop .flex-control-nav, .hide-navigation-desktop .filmstrip{ display: none!important; }}
+@media only screen and (max-width: 767px) {body:after { display: none; content: "smartphone"; } .hide-arrows-smartphone .flex-direction-nav, .hide-navigation-smartphone .flex-control-paging, .hide-navigation-smartphone .flex-control-nav, .hide-navigation-smartphone .filmstrip{ display: none!important; }}@media only screen and (min-width : 768px) and (max-width: 1023px) {body:after { display: none; content: "tablet"; } .hide-arrows-tablet .flex-direction-nav, .hide-navigation-tablet .flex-control-paging, .hide-navigation-tablet .flex-control-nav, .hide-navigation-tablet .filmstrip{ display: none!important; }}@media only screen and (min-width : 1024px) and (max-width: 1439px) {body:after { display: none; content: "laptop"; } .hide-arrows-laptop .flex-direction-nav, .hide-navigation-laptop .flex-control-paging, .hide-navigation-laptop .flex-control-nav, .hide-navigation-laptop .filmstrip{ display: none!important; }}@media only screen and (min-width : 1440px) {body:after { display: none; content: "desktop"; } .hide-arrows-desktop .flex-direction-nav, .hide-navigation-desktop .flex-control-paging, .hide-navigation-desktop .flex-control-nav, .hide-navigation-desktop .filmstrip{ display: none!important; }}
+</style>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/embed-any-document/js/pdfobject.min.js?ver=2.7.4' id='awsm-ead-pdf-object-js'></script>
+<script type='text/javascript' id='awsm-ead-public-js-extra'>
+/* <![CDATA[ */
+var eadPublic = [];
+/* ]]> */
+</script>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/embed-any-document/js/embed-public.min.js?ver=2.7.4' id='awsm-ead-public-js'></script>
+<script type='text/javascript' id='scroll-back-to-top-js-extra'>
+/* <![CDATA[ */
+var scrollBackToTop = {"scrollDuration":"500","fadeDuration":"0.5"};
+/* ]]> */
+</script>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/scroll-back-to-top/assets/js/scroll-back-to-top.js' id='scroll-back-to-top-js'></script>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri/js/app.min.js?ver=6.2.8' id='habakiri-js'></script>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/ml-slider/assets/sliders/flexslider/jquery.flexslider.min.js?ver=3.93.0' id='metaslider-flex-slider-js'></script>
+<script type='text/javascript' id='metaslider-flex-slider-js-after'>
+var metaslider_38 = function($) {$('#metaslider_38').addClass('flexslider');
+            $('#metaslider_38').flexslider({ 
+                slideshowSpeed:6000,
+                animation:"fade",
+                controlNav:true,
+                directionNav:true,
+                pauseOnHover:true,
+                direction:"horizontal",
+                reverse:false,
+                keyboard:false,
+                touch:true,
+                animationSpeed:2000,
+                prevText:"Previous",
+                nextText:"Next",
+                smoothHeight:false,
+                fadeFirstSlide:false,
+                slideshow:true,
+                pausePlay:false
+            });
+            $(document).trigger('metaslider/initialized', '#metaslider_38');
+        };
+        var timer_metaslider_38 = function() {
+            var slider = !window.jQuery ? window.setTimeout(timer_metaslider_38, 100) : !jQuery.isReady ? window.setTimeout(timer_metaslider_38, 1) : metaslider_38(window.jQuery);
+        };
+        timer_metaslider_38();
+var metaslider_40 = function($) {$('#metaslider_40').addClass('flexslider');
+            $('#metaslider_40').flexslider({ 
+                slideshowSpeed:6000,
+                animation:"fade",
+                controlNav:false,
+                directionNav:false,
+                pauseOnHover:true,
+                direction:"horizontal",
+                reverse:false,
+                keyboard:false,
+                touch:true,
+                animationSpeed:2000,
+                prevText:"Previous",
+                nextText:"Next",
+                smoothHeight:false,
+                fadeFirstSlide:false,
+                slideshow:true,
+                pausePlay:false
+            });
+            $(document).trigger('metaslider/initialized', '#metaslider_40');
+        };
+        var timer_metaslider_40 = function() {
+            var slider = !window.jQuery ? window.setTimeout(timer_metaslider_40, 100) : !jQuery.isReady ? window.setTimeout(timer_metaslider_40, 1) : metaslider_40(window.jQuery);
+        };
+        timer_metaslider_40();
+</script>
+<script type='text/javascript' id='metaslider-script-js-extra'>
+/* <![CDATA[ */
+var wpData = {"baseUrl":"https:\/\/www.keisatsubyoin.or.jp"};
+var wpData = {"baseUrl":"https:\/\/www.keisatsubyoin.or.jp"};
+/* ]]> */
+</script>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/ml-slider/assets/metaslider/script.min.js?ver=3.93.0' id='metaslider-script-js'></script>
+<div id="footerFloatingMenu">
+<ul>
+<li class="ft-tel"><a href="tel:03-5343-5611"><i class="fas fa-phone-volume fa-lg"></i>Call Us</a></li>
+<!--<li class="ft-web"><a href="#" target="_blank"><i class="far fa-calendar-alt"></i>Online Booking</a></li>-->
+<li class="ft-access"><a href="/access/"><i class="fas fa-map-marker-alt"></i>Access</a></li>
+</ul>
+</div>
+<script type="text/javascript" src="https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri-child-1/js-child/jquery.rwdImageMaps.min.js"></script>
+<script>
+//Accordion
+jQuery(function(){
+ 
+    //.accordion1 paragraphs toggle their sibling ul elements when clicked
+jQuery('.accordion1 p').click(function(){
+ 
+jQuery(this).next('ul').slideToggle();
+ 
+});
+});
+//End accordion
+
+//Image map responsiveness
+jQuery(document).ready(function(e) {
+jQuery('img[usemap]').rwdImageMaps()
+});
+//End image map responsiveness
+jQuery(window).on('load', function() {
+var url = jQuery(location).attr('href');
+if(url.indexOf("#") != -1){
+var anchor = url.split("#");
+var target = jQuery('#' + anchor[anchor.length - 1]);
+if(target.length){
+var pos = Math.floor(target.offset().top) - 180;
+jQuery("html, body").animate({scrollTop:pos}, 300);
+}
+}
+});
+
+</script>
+<script>
+jQuery(function() {
+jQuery('.nav-tab > li').on('click',function(){
+jQuery('.nav-tab > li').removeClass('active')
+jQuery(this).addClass('active')
+var index = jQuery('.nav-tab > li').index(this);
+jQuery('#categoryTab > ul').removeClass('show'); 
+jQuery('#categoryTab > ul').eq(index).addClass('show'); 
+});
+});
+</script>
+
+<script>
+(function() {
+  var map = [
+    {prefix: "/", to: "./index.html"},
+    {prefix: "/profile/", to: "./about.html"},
+    {prefix: "/shinryoka/", to: "./departments.html"},
+    {prefix: "/gairai/", to: "./outpatient.html"},
+    {prefix: "/nyuin/", to: "./inpatient.html"},
+    {prefix: "/support/", to: "./support.html"},
+    {prefix: "/access/", to: "./access.html"}
+  ];
+  function remap(u) {
+    var p = u.pathname || "/";
+    var m = map.slice().sort(function(a, b) {
+      return b.prefix.length - a.prefix.length;
+    }).find(function(x) {
+      return p.indexOf(x.prefix) === 0;
+    });
+    return m ? m.to : null;
+  }
+  document.addEventListener('DOMContentLoaded', function() {
+    document.querySelectorAll('a[href]').forEach(function(a) {
+      try {
+        var u = new URL(a.getAttribute('href'), location.href);
+        if (/(^|\.)keisatsubyoin\.or\.jp$/i.test(u.hostname)) {
+          var to = remap(u);
+          if (to) {
+            a.setAttribute('href', to);
+          }
+        }
+      } catch (e) {}
+    });
+  });
+})();
+</script>
+
+</body>
+</html>

--- a/departments.html
+++ b/departments.html
@@ -1,0 +1,659 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en" prefix="og: https://ogp.me/ns#">
+<head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# article: http://ogp.me/ns/article#">
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<link rel="shortcut icon" href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2022/12/favicon.png" />
+<link rel="pingback" href="https://www.keisatsubyoin.or.jp/wordpress/xmlrpc.php" />
+<link href="https://use.fontawesome.com/releases/v5.0.10/css/all.css" rel="stylesheet">
+<link rel="stylesheet" href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri-child-1/css/pageheader-style.css" />
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-VTBF3Q2K4B"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-VTBF3Q2K4B');
+</script>
+<!--[if lt IE 9]>
+<script src="https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri/js/html5shiv.min.js"></script>
+<![endif]-->
+<title>Departments | Tokyo Metropolitan Police Hospital</title>
+
+<!-- All in One SEO 4.7.6 - aioseo.com -->
+<meta name="description" content="Content coming soon." />
+<meta name="robots" content="max-image-preview:large" />
+<meta name="msvalidate.01" content="6025B7F66D63703BEED4E4073634721A" />
+<link rel="canonical" href="./departments.html" />
+<meta name="generator" content="All in One SEO (AIOSEO) 4.7.6" />
+
+<meta name="google-site-verification" content="97tlZIAoAnOmR7w1s9-GNtXfEEnBRDb7DyN4QJ3Lv3s" />
+<meta property="og:locale" content="en_US" />
+<meta property="og:site_name" content="Tokyo Metropolitan Police Hospital | Medical Care That Protects Those You Love | Tokyo Metropolitan Police Hospital in Nakano Ward Welcomes All Community Members" />
+<meta property="og:type" content="website" />
+<meta property="og:title" content="Departments | Tokyo Metropolitan Police Hospital" />
+<meta property="og:description" content="Medical care that protects those you love | Tokyo Metropolitan Police Hospital in Nakano Ward welcomes anyone in the community." />
+<meta property="og:url" content="./departments.html" />
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content="Departments | Tokyo Metropolitan Police Hospital" />
+<meta name="twitter:description" content="Content coming soon." />
+<script type="application/ld+json" class="aioseo-schema">
+{"@context":"https:\/\/schema.org","@graph":[{"@type":"BreadcrumbList","@id":"https:\/\/www.keisatsubyoin.or.jp\/#breadcrumblist","itemListElement":[{"@type":"ListItem","@id":"https:\/\/www.keisatsubyoin.or.jp\/#listItem","position":1,"name":"Home"}]},{"@type":"Organization","@id":"https:\/\/www.keisatsubyoin.or.jp\/#organization","name":"Tokyo Metropolitan Police Hospital","description":"Medical care that protects those you love | Tokyo Metropolitan Police Hospital in Nakano Ward welcomes anyone in the community.","url":"https:\/\/www.keisatsubyoin.or.jp\/"},{"@type":"WebPage","@id":"https:\/\/www.keisatsubyoin.or.jp\/#webpage","url":"https:\/\/www.keisatsubyoin.or.jp\/","name":"Tokyo Metropolitan Police Hospital | Medical Care That Protects Those You Love | Tokyo Metropolitan Police Hospital in Nakano Ward Welcomes All Community Members","description":"Medical care that protects those you love | Tokyo Metropolitan Police Hospital in Nakano Ward welcomes anyone in the community.","inLanguage":"en","isPartOf":{"@id":"https:\/\/www.keisatsubyoin.or.jp\/#website"},"breadcrumb":{"@id":"https:\/\/www.keisatsubyoin.or.jp\/#breadcrumblist"},"datePublished":"2019-12-03T08:15:37+09:00","dateModified":"2025-05-01T10:08:09+09:00"},{"@type":"WebSite","@id":"https:\/\/www.keisatsubyoin.or.jp\/#website","url":"https:\/\/www.keisatsubyoin.or.jp\/","name":"Tokyo Metropolitan Police Hospital","description":"Medical care that protects those you love | Tokyo Metropolitan Police Hospital in Nakano Ward welcomes anyone in the community.","inLanguage":"en","publisher":{"@id":"https:\/\/www.keisatsubyoin.or.jp\/#organization"},"potentialAction":{"@type":"SearchAction","target":{"@type":"EntryPoint","urlTemplate":"https:\/\/www.keisatsubyoin.or.jp\/?s={search_term_string}"},"query-input":"required name=search_term_string"}}]}
+</script>
+<!-- All in One SEO -->
+
+<link rel='dns-prefetch' href='//netdna.bootstrapcdn.com' />
+<link rel="alternate" type="application/rss+xml" title="Tokyo Metropolitan Police Hospital &raquo; Feed" href="https://www.keisatsubyoin.or.jp/feed/" />
+<script type="text/javascript">
+window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/14.0.0\/72x72\/","ext":".png","svgUrl":"https:\/\/s.w.org\/images\/core\/emoji\/14.0.0\/svg\/","svgExt":".svg","source":{"concatemoji":"https:\/\/www.keisatsubyoin.or.jp\/wordpress\/wp-includes\/js\/wp-emoji-release.min.js?ver=6.2.8"}};
+/*! This file is auto-generated */
+!function(e,a,t){var n,r,o,i=a.createElement("canvas"),p=i.getContext&&i.getContext("2d");function s(e,t){p.clearRect(0,0,i.width,i.height),p.fillText(e,0,0);e=i.toDataURL();return p.clearRect(0,0,i.width,i.height),p.fillText(t,0,0),e===i.toDataURL()}function c(e){var t=a.createElement("script");t.src=e,t.defer=t.type="text/javascript",a.getElementsByTagName("head")[0].appendChild(t)}for(o=Array("flag","emoji"),t.supports={everything:!0,everythingExceptFlag:!0},r=0;r<o.length;r++)t.supports[o[r]]=function(e){if(p&&p.fillText)switch(p.textBaseline="top",p.font="600 32px Arial",e){case"flag":return s("\ud83c\udff3\ufe0f\u200d\u26a7\ufe0f","\ud83c\udff3\ufe0f\u200b\u26a7\ufe0f")?!1:!s("\ud83c\uddfa\ud83c\uddf3","\ud83c\uddfa\u200b\ud83c\uddf3")&&!s("\ud83c\udff4\udb40\udc67\udb40\udc62\udb40\udc65\udb40\udc6e\udb40\udc67\udb40\udc7f","\ud83c\udff4\u200b\udb40\udc67\u200b\udb40\udc62\u200b\udb40\udc65\u200b\udb40\udc6e\u200b\udb40\udc67\u200b\udb40\udc7f");case"emoji":return!s("\ud83e\udef1\ud83c\udffb\u200d\ud83e\udef2\ud83c\udfff","\ud83e\udef1\ud83c\udffb\u200b\ud83e\udef2\ud83c\udfff")}return!1}(o[r]),t.supports.everything=t.supports.everything&&t.supports[o[r]],"flag"!==o[r]&&(t.supports.everythingExceptFlag=t.supports.everythingExceptFlag&&t.supports[o[r]]);t.supports_everythingExceptFlag=t.supports.everythingExceptFlag&&!t.supports.flag,t.DOMReady=!1,t.readyCallback=function(){t.DOMReady=!0},t.supports.everything||(n=function(){t.readyCallback()},a.addEventListener?(a.addEventListener("DOMContentLoaded",n,!1),e.addEventListener("load",n,!1)):(e.attachEvent("onload",n),a.attachEvent("onreadystatechange",function(){"complete"===a.readyState&&t.readyCallback()})),(e=t.source||{}).concatemoji?c(e.concatemoji):e.wpemoji&&e.twemoji&&(c(e.twemoji),c(e.wpemoji)))}(window,document,window._wpemojiSettings);
+</script>
+<style type="text/css">
+img.wp-smiley,
+img.emoji {
+display: inline !important;
+border: none !important;
+box-shadow: none !important;
+height: 1em !important;
+width: 1em !important;
+margin: 0 0.07em !important;
+vertical-align: -0.1em !important;
+background: none !important;
+padding: 0 !important;
+}
+</style>
+<link rel='stylesheet' id='wp-block-library-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-includes/css/dist/block-library/style.min.css?ver=6.2.8' type='text/css' media='all' />
+<style id='pdfemb-pdf-embedder-viewer-style-inline-css' type='text/css'>
+.wp-block-pdfemb-pdf-embedder-viewer{max-width:none}
+
+</style>
+<link rel='stylesheet' id='awsm-ead-public-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/embed-any-document/css/embed-public.min.css?ver=2.7.4' type='text/css' media='all' />
+<link rel='stylesheet' id='classic-theme-styles-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-includes/css/classic-themes.min.css?ver=6.2.8' type='text/css' media='all' />
+<style id='global-styles-inline-css' type='text/css'>
+body{
+--wp--preset--color--black: #000000;
+--wp--preset--color--cyan-bluish-gray: #abb8c3;
+--wp--preset--color--white: #ffffff;
+--wp--preset--color--pale-pink: #f78da7;
+--wp--preset--color--vivid-red: #cf2e2e;
+--wp--preset--color--luminous-vivid-orange: #ff6900;
+--wp--preset--color--luminous-vivid-amber: #fcb900;
+--wp--preset--color--light-green-cyan: #7bdcb5;
+--wp--preset--color--vivid-green-cyan: #00d084;
+--wp--preset--color--pale-cyan-blue: #8ed1fc;
+--wp--preset--color--vivid-cyan-blue: #0693e3;
+--wp--preset--color--vivid-purple: #9b51e0;
+--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%);
+--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan: linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%);
+--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange: linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%);
+--wp--preset--gradient--luminous-vivid-orange-to-vivid-red: linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%);
+--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray: linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%);
+--wp--preset--gradient--cool-to-warm-spectrum: linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186) 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%);
+--wp--preset--gradient--blush-light-purple: linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%);
+--wp--preset--gradient--blush-bordeaux: linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%);
+--wp--preset--gradient--luminous-dusk: linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%);
+--wp--preset--gradient--pale-ocean: linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181) 100%);
+--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128) 0%,rgb(113,206,126) 100%);
+--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%);
+--wp--preset--duotone--dark-grayscale: url('#wp-duotone-dark-grayscale');
+--wp--preset--duotone--grayscale: url('#wp-duotone-grayscale');
+--wp--preset--duotone--purple-yellow: url('#wp-duotone-purple-yellow');
+--wp--preset--duotone--blue-red: url('#wp-duotone-blue-red');
+--wp--preset--duotone--midnight: url('#wp-duotone-midnight');
+--wp--preset--duotone--magenta-yellow: url('#wp-duotone-magenta-yellow');
+--wp--preset--duotone--purple-green: url('#wp-duotone-purple-green');
+--wp--preset--duotone--blue-orange: url('#wp-duotone-blue-orange');
+--wp--preset--font-size--small: 13px;
+--wp--preset--font-size--medium: 20px;
+--wp--preset--font-size--large: 36px;
+--wp--preset--font-size--x-large: 42px;
+--wp--preset--spacing--20: 0.44rem;
+--wp--preset--spacing--30: 0.67rem;
+--wp--preset--spacing--40: 1rem;
+--wp--preset--spacing--50: 1.5rem;
+--wp--preset--spacing--60: 2.25rem;
+--wp--preset--spacing--70: 3.38rem;
+--wp--preset--spacing--80: 5.06rem;
+--wp--preset--shadow--natural: 6px 6px 9px rgba(0, 0, 0, 0.2);
+--wp--preset--shadow--deep: 12px 12px 50px rgba(0, 0, 0, 0.4);
+--wp--preset--shadow--sharp: 6px 6px 0px rgba(0, 0, 0, 0.2);
+--wp--preset--shadow--outlined: 6px 6px 0px -3px rgba(255, 255, 255, 1), 6px 6px rgba(0, 0, 0, 1);
+--wp--preset--shadow--crisp: 6px 6px 0px rgba(0, 0, 0, 1);
+}
+:where(.is-layout-flex){gap: 0.5em;}
+body .is-layout-flow > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}
+body .is-layout-flow > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}
+body .is-layout-flow > .aligncenter{margin-left: auto !important;margin-right: auto !important;}
+body .is-layout-constrained > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}
+body .is-layout-constrained > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}
+body .is-layout-constrained > .aligncenter{margin-left: auto !important;margin-right: auto !important;}
+body .is-layout-constrained > :where(:not(.alignleft):not(.alignright):not(.alignfull)){max-width: var(--wp--style--global--content-size);margin-left: auto !important;margin-right: auto !important;}
+body .is-layout-constrained > .alignwide{max-width: var(--wp--style--global--wide-size);}
+body .is-layout-flex{display: flex;}
+body .is-layout-flex{flex-wrap: wrap;align-items: center;}
+body .is-layout-flex > *{margin: 0;}
+:where(.wp-block-columns.is-layout-flex){gap: 2em;}
+.has-black-color{color: var(--wp--preset--color--black) !important;}
+.has-cyan-bluish-gray-color{color: var(--wp--preset--color--cyan-bluish-gray) !important;}
+.has-white-color{color: var(--wp--preset--color--white) !important;}
+.has-pale-pink-color{color: var(--wp--preset--color--pale-pink) !important;}
+.has-vivid-red-color{color: var(--wp--preset--color--vivid-red) !important;}
+.has-luminous-vivid-orange-color{color: var(--wp--preset--color--luminous-vivid-orange) !important;}
+.has-luminous-vivid-amber-color{color: var(--wp--preset--color--luminous-vivid-amber) !important;}
+.has-light-green-cyan-color{color: var(--wp--preset--color--light-green-cyan) !important;}
+.has-vivid-green-cyan-color{color: var(--wp--preset--color--vivid-green-cyan) !important;}
+.has-pale-cyan-blue-color{color: var(--wp--preset--color--pale-cyan-blue) !important;}
+.has-vivid-cyan-blue-color{color: var(--wp--preset--color--vivid-cyan-blue) !important;}
+.has-vivid-purple-color{color: var(--wp--preset--color--vivid-purple) !important;}
+.has-black-background-color{background-color: var(--wp--preset--color--black) !important;}
+.has-cyan-bluish-gray-background-color{background-color: var(--wp--preset--color--cyan-bluish-gray) !important;}
+.has-white-background-color{background-color: var(--wp--preset--color--white) !important;}
+.has-pale-pink-background-color{background-color: var(--wp--preset--color--pale-pink) !important;}
+.has-vivid-red-background-color{background-color: var(--wp--preset--color--vivid-red) !important;}
+.has-luminous-vivid-orange-background-color{background-color: var(--wp--preset--color--luminous-vivid-orange) !important;}
+.has-luminous-vivid-amber-background-color{background-color: var(--wp--preset--color--luminous-vivid-amber) !important;}
+.has-light-green-cyan-background-color{background-color: var(--wp--preset--color--light-green-cyan) !important;}
+.has-vivid-green-cyan-background-color{background-color: var(--wp--preset--color--vivid-green-cyan) !important;}
+.has-pale-cyan-blue-background-color{background-color: var(--wp--preset--color--pale-cyan-blue) !important;}
+.has-vivid-cyan-blue-background-color{background-color: var(--wp--preset--color--vivid-cyan-blue) !important;}
+.has-vivid-purple-background-color{background-color: var(--wp--preset--color--vivid-purple) !important;}
+.has-black-border-color{border-color: var(--wp--preset--color--black) !important;}
+.has-cyan-bluish-gray-border-color{border-color: var(--wp--preset--color--cyan-bluish-gray) !important;}
+.has-white-border-color{border-color: var(--wp--preset--color--white) !important;}
+.has-pale-pink-border-color{border-color: var(--wp--preset--color--pale-pink) !important;}
+.has-vivid-red-border-color{border-color: var(--wp--preset--color--vivid-red) !important;}
+.has-luminous-vivid-orange-border-color{border-color: var(--wp--preset--color--luminous-vivid-orange) !important;}
+.has-luminous-vivid-amber-border-color{border-color: var(--wp--preset--color--luminous-vivid-amber) !important;}
+.has-light-green-cyan-border-color{border-color: var(--wp--preset--color--light-green-cyan) !important;}
+.has-vivid-green-cyan-border-color{border-color: var(--wp--preset--color--vivid-green-cyan) !important;}
+.has-pale-cyan-blue-border-color{border-color: var(--wp--preset--color--pale-cyan-blue) !important;}
+.has-vivid-cyan-blue-border-color{border-color: var(--wp--preset--color--vivid-cyan-blue) !important;}
+.has-vivid-purple-border-color{border-color: var(--wp--preset--color--vivid-purple) !important;}
+.has-vivid-cyan-blue-to-vivid-purple-gradient-background{background: var(--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple) !important;}
+.has-light-green-cyan-to-vivid-green-cyan-gradient-background{background: var(--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan) !important;}
+.has-luminous-vivid-amber-to-luminous-vivid-orange-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange) !important;}
+.has-luminous-vivid-orange-to-vivid-red-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-orange-to-vivid-red) !important;}
+.has-very-light-gray-to-cyan-bluish-gray-gradient-background{background: var(--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray) !important;}
+.has-cool-to-warm-spectrum-gradient-background{background: var(--wp--preset--gradient--cool-to-warm-spectrum) !important;}
+.has-blush-light-purple-gradient-background{background: var(--wp--preset--gradient--blush-light-purple) !important;}
+.has-blush-bordeaux-gradient-background{background: var(--wp--preset--gradient--blush-bordeaux) !important;}
+.has-luminous-dusk-gradient-background{background: var(--wp--preset--gradient--luminous-dusk) !important;}
+.has-pale-ocean-gradient-background{background: var(--wp--preset--gradient--pale-ocean) !important;}
+.has-electric-grass-gradient-background{background: var(--wp--preset--gradient--electric-grass) !important;}
+.has-midnight-gradient-background{background: var(--wp--preset--gradient--midnight) !important;}
+.has-small-font-size{font-size: var(--wp--preset--font-size--small) !important;}
+.has-medium-font-size{font-size: var(--wp--preset--font-size--medium) !important;}
+.has-large-font-size{font-size: var(--wp--preset--font-size--large) !important;}
+.has-x-large-font-size{font-size: var(--wp--preset--font-size--x-large) !important;}
+.wp-block-navigation a:where(:not(.wp-element-button)){color: inherit;}
+:where(.wp-block-columns.is-layout-flex){gap: 2em;}
+.wp-block-pullquote{font-size: 1.5em;line-height: 1.6;}
+</style>
+<link rel='stylesheet' id='font-awesome-css' href='//netdna.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.css' type='text/css' media='screen' />
+<link rel='stylesheet' id='habakiri-assets-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri/css/assets.min.css?ver=6.2.8' type='text/css' media='all' />
+<link rel='stylesheet' id='habakiri-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri/style.min.css?ver=20250926050751' type='text/css' media='all' />
+<link rel='stylesheet' id='habakiri-child-1-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri-child-1/style.css?ver=20250926050751' type='text/css' media='all' />
+<link rel='stylesheet' id='msl-main-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/master-slider/public/assets/css/masterslider.main.css?ver=3.10.0' type='text/css' media='all' />
+<link rel='stylesheet' id='msl-custom-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/master-slider/custom.css?ver=4.5' type='text/css' media='all' />
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-includes/js/jquery/jquery.min.js?ver=3.6.4' id='jquery-core-js'></script>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-includes/js/jquery/jquery-migrate.min.js?ver=3.4.0' id='jquery-migrate-js'></script>
+<link rel="https://api.w.org/" href="https://www.keisatsubyoin.or.jp/wp-json/" /><link rel="alternate" type="application/json" href="https://www.keisatsubyoin.or.jp/wp-json/wp/v2/pages/22" /><link rel="EditURI" type="application/rsd+xml" title="RSD" href="https://www.keisatsubyoin.or.jp/wordpress/xmlrpc.php?rsd" />
+<link rel="wlwmanifest" type="application/wlwmanifest+xml" href="https://www.keisatsubyoin.or.jp/wordpress/wp-includes/wlwmanifest.xml" />
+<meta name="generator" content="WordPress 6.2.8" />
+<link rel='shortlink' href='https://www.keisatsubyoin.or.jp/' />
+<link rel="alternate" type="application/json+oembed" href="https://www.keisatsubyoin.or.jp/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.keisatsubyoin.or.jp%2F" />
+<link rel="alternate" type="text/xml+oembed" href="https://www.keisatsubyoin.or.jp/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.keisatsubyoin.or.jp%2F&#038;format=xml" />
+<script>var ms_grabbing_curosr = 'https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/master-slider/public/assets/css/common/grabbing.cur', ms_grab_curosr = 'https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/master-slider/public/assets/css/common/grab.cur';</script>
+<meta name="generator" content="MasterSlider 3.10.0 - Responsive Touch Image Slider | avt.li/msf" />
+
+<style>
+.scroll-back-to-top-wrapper {
+    position: fixed;
+opacity: 0;
+visibility: hidden;
+overflow: hidden;
+text-align: center;
+z-index: 99999999;
+    background-color: #777777;
+color: #eeeeee;
+width: 50px;
+height: 48px;
+line-height: 48px;
+right: 30px;
+bottom: 60px;
+padding-top: 2px;
+border-top-left-radius: 10px;
+border-top-right-radius: 10px;
+border-bottom-right-radius: 10px;
+border-bottom-left-radius: 10px;
+-webkit-transition: all 0.5s ease-in-out;
+-moz-transition: all 0.5s ease-in-out;
+-ms-transition: all 0.5s ease-in-out;
+-o-transition: all 0.5s ease-in-out;
+transition: all 0.5s ease-in-out;
+}
+.scroll-back-to-top-wrapper:hover {
+background-color: #888888;
+  color: #eeeeee;
+}
+.scroll-back-to-top-wrapper.show {
+    visibility:visible;
+    cursor:pointer;
+opacity: 1.0;
+}
+.scroll-back-to-top-wrapper i.fa {
+line-height: inherit;
+}
+.scroll-back-to-top-wrapper .fa-lg {
+vertical-align: 0;
+}
+</style><style>
+/* Safari 6.1+ (10.0 is the latest version of Safari at this time) */
+@media (max-width: 991px) and (min-color-index: 0) and (-webkit-min-device-pixel-ratio: 0) { @media () {
+display: block !important;
+.header__col {
+width: 100%;
+}
+}}
+</style>
+<style>a{color:#337ab7}a:focus,a:active,a:hover{color:#23527c}.site-branding a{color:#000}.responsive-nav a{color:#ffffff;font-size:14px}.responsive-nav a small{color:#707070;font-size:10px}.responsive-nav a:hover small,.responsive-nav a:active small,.responsive-nav .current-menu-item small,.responsive-nav .current-menu-ancestor small,.responsive-nav .current-menu-parent small,.responsive-nav .current_page_item small,.responsive-nav .current_page_parent small{color:#707070}.responsive-nav .menu>.menu-item>a,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.menu-item>a{background-color:#f4a000;padding:12px 7px}.responsive-nav .menu>.menu-item>a:hover,.responsive-nav .menu>.menu-item>a:active,.responsive-nav .menu>.current-menu-item>a,.responsive-nav .menu>.current-menu-ancestor>a,.responsive-nav .menu>.current-menu-parent>a,.responsive-nav .menu>.current_page_item>a,.responsive-nav .menu>.current_page_parent>a,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.menu-item>a:hover,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.menu-item>a:active,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.current-menu-item>a,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.current-menu-ancestor>a,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.current-menu-parent>a,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.current_page_item>a,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.current_page_parent>a{background-color:#f5f5f5;color:#707070}.responsive-nav .sub-menu a{background-color:#f5f5f5;color:#707070}.responsive-nav .sub-menu a:hover,.responsive-nav .sub-menu a:active,.responsive-nav .sub-menu .current-menu-item a,.responsive-nav .sub-menu .current-menu-ancestor a,.responsive-nav .sub-menu .current-menu-parent a,.responsive-nav .sub-menu .current_page_item a,.responsive-nav .sub-menu .current_page_parent a{background-color:#f5f5f5;color:#707070}.off-canvas-nav{font-size:12px}.responsive-nav,.header--transparency.header--fixed--is_scrolled .responsive-nav{background-color:#f4a000}#responsive-btn{background-color:transparent;border-color:#eeeeee;color:#000}#responsive-btn:hover{background-color:#f5f5f5;border-color:#eee;color:#000}.habakiri-slider__transparent-layer{background-color:rgba( 0,0,0, 0.1 )}.page-header{background-color:#dddddd;color:#fff}.pagination>li>a{color:#337ab7}.pagination>li>span{background-color:#337ab7;border-color:#337ab7}.pagination>li>a:focus,.pagination>li>a:hover,.pagination>li>span:focus,.pagination>li>span:hover{color:#23527c}.header{background-color:#fff}.header--transparency.header--fixed--is_scrolled{background-color:#fff !important}.footer{background-color:#f49000}.footer-widget-area a{color:#777}.footer-widget-area,.footer-widget-area .widget_calendar #wp-calendar caption{color:#555}.footer-widget-area .widget_calendar #wp-calendar,.footer-widget-area .widget_calendar #wp-calendar *{border-color:#555}@media(min-width:992px){.responsive-nav{display:block}.off-canvas-nav,#responsive-btn{display:none !important}.header--2row{padding-bottom:0}.header--2row .header__col,.header--center .header__col{display:block}.header--2row .responsive-nav,.header--center .responsive-nav{margin-right:-1000px;margin-left:-1000px;padding-right:1000px;padding-left:1000px}.header--center .site-branding{text-align:center}}</style><link rel="icon" href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2022/12/favicon.png" sizes="32x32" />
+<link rel="icon" href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2022/12/favicon.png" sizes="192x192" />
+<link rel="apple-touch-icon" href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2022/12/favicon.png" />
+<meta name="msapplication-TileImage" content="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2022/12/favicon.png" />
+<style type="text/css" id="wp-custom-css">
+.cl_rd {
+color: #F00;
+}
+.responsive-nav .sub-menu a {
+background-color: #f5f5f5;
+color: #707070;
+font-weight:bold
+}
+body{
+  word-wrap : break-word;
+  overflow-wrap : break-word;
+}
+
+img {
+    -webkit-backface-visibility: hidden;
+}
+@media print {
+.scroll-back-to-top-wrapper{
+display: none !important;
+}
+}
+
+.spmenu2 {
+             padding:  10px 0 0;
+    }
+@media screen and (max-width: 991px) {
+    .spmenu {
+       /* border-bottom: solid 1px #ffcf74;*/
+        padding:  0 0 10px;
+width: 100%;
+    }
+}</style>
+</head>
+<body data-rsssl=1 class="home page-template page-template-templates page-template-rich-front-page page-template-templatesrich-front-page-php page page-id-22 _masterslider _ms_version_3.10.0">
+<div id="container">
+<header id="header" class="header header--2row ">
+<div class="container">
+<div class="row header__content">
+<div class="col-xs-10 col-md-12 header__col">
+<div class ="row">
+<div class="col-md-6 col-sm-12">
+
+<div class="site-branding">
+<h1 class="site-branding__heading">
+<a href="./index.html" rel="home"><img src="https://keisatsubyoin.or.jp/wordpress/wp-content/uploads/2020/03/logo.png" alt="Tokyo Metropolitan Police Hospital" class="site-branding__logo" /></a></h1>
+<!-- end .site-branding --></div>
+                        </div>
+<div class="col-md-6 col-sm-12 h-btn-flex">
+<div id="site-cr">
+<a href="./index.html" class="h-btn current">Website for Patients</a>
+<a href="https://www.keisatsubyoin.or.jp/m/" class="h-btn">Website for Healthcare Professionals</a>
+</div>
+                        <ul class="topnav2">
+<li class="f-cv-tel"><i class="fas fa-phone-volume"></i>03-5343-5611<span style="font-size:12px"> (Main)</span><!--<span class="h-time">【Reception Hours】8:00~11:30/12:30~16:00</span>--></li>
+</ul>
+                        </div>
+                 </div>
+         <!-- end .header__col --></div>
+<div class="col-xs-2 col-md-12 header__col global-nav-wrapper clearfix">
+
+<nav class="global-nav js-responsive-nav nav--hide" role="navigation">
+<div class="menu-gnavi-container"><ul id="menu-gnavi" class="menu"><li id="menu-item-35" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-35"><a href="./index.html"><div class="m-icon"><i class="fas fa-home"></i>Home</div></a></li>
+<li id="menu-item-157" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-157"><a href="./outpatient.html"><div class="m-icon"><i class="fas fa-stethoscope"></i>Outpatient Visits</div></a>
+<ul class="sub-menu">
+<li id="menu-item-170" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-170"><a href="./outpatient.html">For First-Time Patients</a></li>
+<li id="menu-item-172" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-172"><a href="./outpatient.html">For Returning Patients</a></li>
+<li id="menu-item-12181" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-12181"><a href="./outpatient.html">About Nighttime &amp; Holiday Clinics</a></li>
+<li id="menu-item-171" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-171"><a href="./outpatient.html">For Patients with Referral Letters</a></li>
+<li id="menu-item-10898" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-10898"><a href="./outpatient.html">About Focused Referral Medical Institutions</a></li>
+<li id="menu-item-169" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-169"><a href="./outpatient.html">Community Primary Care Physicians</a></li>
+<li id="menu-item-158" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-158"><a href="./outpatient.html">About Medications</a></li>
+</ul>
+</li>
+<li id="menu-item-32" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-32"><a href="./departments.html"><div class="m-icon"><i class="fas fa-syringe"></i>Departments &amp; Divisions</div></a></li>
+<li id="menu-item-190" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-190"><a href="./inpatient.html"><div class="m-icon"><i class="fas fa-bed"></i>Inpatient Guide</div></a>
+<ul class="sub-menu">
+<li id="menu-item-194" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-194"><a href="./inpatient.html">Admission &amp; Discharge</a></li>
+<li id="menu-item-191" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-191"><a href="./inpatient.html">For Visitors</a></li>
+<li id="menu-item-193" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-193"><a href="./inpatient.html">Life During Hospitalization</a></li>
+<li id="menu-item-196" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-196"><a href="./inpatient.html">About Patient Rooms</a></li>
+<li id="menu-item-192" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-192"><a href="./inpatient.html">Messages to Inpatients</a></li>
+<li id="menu-item-195" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-195"><a href="./inpatient.html">About DPC</a></li>
+</ul>
+</li>
+<li id="menu-item-332" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-332"><a href="./about.html"><div class="m-icon"><i class="fas fa-hospital-alt"></i>About the Hospital</div></a>
+<ul class="sub-menu">
+<li id="menu-item-330" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-330"><a href="./about.html">Message from the Hospital Director</a></li>
+<li id="menu-item-338" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-338"><a href="./about.html">Overview &amp; History</a></li>
+<li id="menu-item-318" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-318"><a href="./about.html">Philosophy &amp; Core Policies</a></li>
+<li id="menu-item-5336" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-5336"><a href="./about.html">Policy on Refusal of Blood Transfusions</a></li>
+<li id="menu-item-317" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-317"><a href="./about.html">Patients' Rights &amp; Responsibilities</a></li>
+<li id="menu-item-7761" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-7761"><a href="./about.html">Request for Comprehensive Consent</a></li>
+<li id="menu-item-319" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-319"><a href="./about.html">Partnership with Patients</a></li>
+<li id="menu-item-329" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-329"><a href="./about.html">Facility Guide</a></li>
+<li id="menu-item-321" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-321"><a href="./about.html">Professional Accreditations</a></li>
+<li id="menu-item-322" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-322"><a href="./about.html">Advanced Medical Equipment</a></li>
+<li id="menu-item-323" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-323"><a href="./about.html">Accredited Hospital Functions</a></li>
+<li id="menu-item-325" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-325"><a href="./about.html">Tokyo Police Hospital by the Numbers</a></li>
+<li id="menu-item-4097" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4097"><a href="https://www.keisatsubyoin.or.jp/privacy/">Privacy Policy</a></li>
+<li id="menu-item-4098" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4098"><a href="https://www.keisatsubyoin.or.jp/nextgeneration/">Next Generation Development Support Measures</a></li>
+<li id="menu-item-4099" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4099"><a href="https://www.keisatsubyoin.or.jp/josei/">Women's Advancement Promotion Plan</a></li>
+<li id="menu-item-4197" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4197"><a href="./about.html">Notices Required by the Minister of Health, Labour and Welfare</a></li>
+</ul>
+</li>
+<li id="menu-item-357" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-357"><a href="./support.html"><div class="m-icon"><i class="fas fa-comment-dots"></i>Consultation &amp; Support</div></a>
+<ul class="sub-menu">
+<li id="menu-item-364" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-364"><a href="./support.html">Information Desk</a></li>
+<li id="menu-item-365" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-365"><a href="./support.html">About Second Opinions</a></li>
+<li id="menu-item-362" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-362"><a href="./support.html">Nutrition Counseling &amp; Guidance</a></li>
+<li id="menu-item-361" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-361"><a href="./support.html">Medical Social Services</a></li>
+<li id="menu-item-359" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-359"><a href="./support.html">Access to Medical Records</a></li>
+<li id="menu-item-358" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-358"><a href="./support.html">Clinical Support Team</a></li>
+<li id="menu-item-360" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-360"><a href="./support.html">Frequently Asked Questions</a></li>
+<li id="menu-item-363" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-363"><a href="./support.html">Patient Safety</a></li>
+<li id="menu-item-1573" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1573"><a href="./support.html">Telephone Use</a></li>
+<li id="menu-item-4209" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4209"><a href="./support.html">Suggestion Box</a></li>
+<li id="menu-item-1577" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-1577"><a href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2023/03/患者さま図書コーナーのご案内.pdf">Patient Library Corner</a></li>
+<li id="menu-item-4100" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4100"><a href="https://www.keisatsubyoin.or.jp/news_090821_dog/">Assistance Dogs for Persons with Disabilities</a></li>
+<li id="menu-item-4101" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4101"><a href="https://www.keisatsubyoin.or.jp/research/">Clinical Trials &amp; Research</a></li>
+</ul>
+</li>
+<li id="menu-item-31" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-31"><a href="./access.html"><div class="m-icon"><i class="fas fa-map-marker-alt"></i>Access</div></a></li>
+</ul></div><!-- end .global-nav --></nav>
+<div id="responsive-btn"></div>
+</div>
+<!-- end .header__col --></div>
+<!-- end .container --></div>
+<!-- end #header --></header>
+<div id="contents">
+  <main class="container" role="main">
+    <h1>Departments & Services</h1>
+    <p>Content coming soon.</p>
+  </main>
+<!-- end #contents --></div>
+<footer id="footer" class="footer">
+
+
+<div class="f-menuArea">
+<div class="container">
+<ul class="f-menu">
+<li>
+<div class="spmenu"><i class="fas fa-chevron-right"></i><a href="./outpatient.html">Outpatient Visits</a></div>
+<ul class="f-sub-menu">
+<li><a href="./outpatient.html">For First-Time Patients</a></li>
+<li><a href="./outpatient.html">For Returning Patients</a></li>
+<li><a href="./outpatient.html">Nighttime &amp; Holiday (After-Hours) Clinics</a></li>
+<li><a href="./outpatient.html">For Patients with Referral Letters</a></li>
+<li><a href="./outpatient.html">About Focused Referral Medical Institutions</a></li>
+<li><a href="./outpatient.html">Keep a Community Primary Care Physician</a></li>
+<li><a href="./outpatient.html">About Medications</a></li>
+</ul>
+<div class="spmenu2"><i class="fas fa-chevron-right"></i><a href="./departments.html">Departments &amp; Divisions</a></div>
+</li>
+<li><i class="fas fa-chevron-right"></i><a href="./inpatient.html">Inpatient Guide</a>
+<ul class="f-sub-menu">
+<li><a href="./inpatient.html">About Admission &amp; Discharge</a></li>
+<li><a href="./inpatient.html">For Visitors</a></li>
+<li><a href="./inpatient.html">Life During Hospitalization</a></li>
+<li><a href="./inpatient.html">About Patient Rooms</a></li>
+<li><a href="./inpatient.html">About Messages to Patients</a></li>
+<li><a href="./inpatient.html">About DPC</a></li>
+</ul>
+</li>
+<li><i class="fas fa-chevron-right"></i><a href="./about.html">About the Hospital</a>
+<ul class="f-sub-menu">
+<li><a href="./about.html">Message from the Hospital Director</a></li>
+<li><a href="./about.html">Hospital Overview</a></li>
+<li><a href="./about.html">Philosophy / Core Policies</a></li>
+<li><a href="./about.html">Policy on Refusal of Blood Transfusions</a></li>
+<li><a href="./about.html">Patients' Rights &amp; Responsibilities</a></li>
+<li><a href="./about.html">Request for Comprehensive Consent</a></li>
+<li><a href="./about.html">Partnership with Patients</a></li>
+<!--<li><a href="./about.html">Organization / Committees</a></li>-->
+<li><a href="./about.html">Floor Guide / On-Site Services</a></li>
+<li><a href="./about.html">Professional Accreditations</a></li>
+<li><a href="./about.html">Advanced Medical Equipment</a></li>
+<li><a href="./about.html">Hospital Function Accreditation</a></li>
+<li><a href="./about.html">Tokyo Police Hospital by the Numbers (Clinical Indicators)</a></li>
+<!--<li><a href="./about.html">History</a></li>-->
+<li><a href="https://www.keisatsubyoin.or.jp/privacy/">Privacy Policy</a></li>
+<li><a href="https://www.keisatsubyoin.or.jp/nextgeneration/">Next Generation Development Support Measures</a></li>
+<li><a href="https://www.keisatsubyoin.or.jp/josei/">Women's Advancement Promotion Plan</a></li>
+<li><a href="./about.html">Notices Required by the Minister of Health, Labour and Welfare</a></li>
+<li><a href="https://www.keisatsubyoin.or.jp/sitemap/">Site Map</a></li>
+</ul>
+</li>
+<li><div class="spmenu"><i class="fas fa-chevron-right"></i><a href="./support.html">Consultation &amp; Support</a></div>
+<ul class="f-sub-menu">
+<li><a href="./support.html">Information Desk</a></li>
+<li><a href="./support.html">Second Opinions</a></li>
+<li><a href="./support.html">Meals &amp; Nutrition Guidance</a></li>
+<li><a href="./support.html">Medical Social Services</a></li>
+<li><a href="./support.html">Access to Medical Records</a></li>
+<li><a href="./support.html">Clinical Support</a></li>
+<li><a href="./support.html">Frequently Asked Questions</a></li>
+<li><a href="./support.html">Patient Safety &amp; Infection Control</a></li>
+<li><a href="./support.html">Telephone Use</a></li>
+<li><a href="./support.html">Suggestion Box</a></li>
+<li><a href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2023/03/患者さま図書コーナーのご案内.pdf">Patient Library Corner</a></li>
+<!--<li><a href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2020/02/vol.11_Kanjasama-Tosyo.pdf#page=1&zoom=200">Patient Library Corner</a></li>-->
+<li><a href="https://www.keisatsubyoin.or.jp/news_090821_dog/">Assistance Dogs for Persons with Disabilities</a></li>
+<li><a href="https://www.keisatsubyoin.or.jp/research/">Clinical Trials &amp; Research</a></li>
+</ul>
+<div class="spmenu2"><i class="fas fa-chevron-right"></i><a href="./access.html">Access</a></div>
+</li>
+</ul>
+</div>
+</div>
+<div class="copyright">
+<div class="container">
+&copy; Tokyo Metropolitan Police Hospital 4-22-1 Nakano, Nakano-ku, Tokyo
+<!-- end .container --></div>
+<!-- end .copyright --></div>
+<!-- end #footer --></footer>
+<!-- end #container --></div>
+<div class="scroll-back-to-top-wrapper">
+<span class="scroll-back-to-top-inner">
+<i class="fa fa-2x fa-arrow-circle-up"></i>
+</span>
+</div><script>
+jQuery( function( $ ) {
+$( '.js-responsive-nav' ).responsive_nav( {
+direction: 'right'
+} );
+} );
+</script>
+<link rel='stylesheet' id='metaslider-flex-slider-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/ml-slider/assets/sliders/flexslider/flexslider.css?ver=3.93.0' type='text/css' media='all' property='stylesheet' />
+<link rel='stylesheet' id='metaslider-public-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/ml-slider/assets/metaslider/public.css?ver=3.93.0' type='text/css' media='all' property='stylesheet' />
+<style id='metaslider-public-inline-css' type='text/css'>
+@media only screen and (max-width: 767px) {body:after { display: none; content: "smartphone"; } .hide-arrows-smartphone .flex-direction-nav, .hide-navigation-smartphone .flex-control-paging, .hide-navigation-smartphone .flex-control-nav, .hide-navigation-smartphone .filmstrip{ display: none!important; }}@media only screen and (min-width : 768px) and (max-width: 1023px) {body:after { display: none; content: "tablet"; } .hide-arrows-tablet .flex-direction-nav, .hide-navigation-tablet .flex-control-paging, .hide-navigation-tablet .flex-control-nav, .hide-navigation-tablet .filmstrip{ display: none!important; }}@media only screen and (min-width : 1024px) and (max-width: 1439px) {body:after { display: none; content: "laptop"; } .hide-arrows-laptop .flex-direction-nav, .hide-navigation-laptop .flex-control-paging, .hide-navigation-laptop .flex-control-nav, .hide-navigation-laptop .filmstrip{ display: none!important; }}@media only screen and (min-width : 1440px) {body:after { display: none; content: "desktop"; } .hide-arrows-desktop .flex-direction-nav, .hide-navigation-desktop .flex-control-paging, .hide-navigation-desktop .flex-control-nav, .hide-navigation-desktop .filmstrip{ display: none!important; }}
+@media only screen and (max-width: 767px) {body:after { display: none; content: "smartphone"; } .hide-arrows-smartphone .flex-direction-nav, .hide-navigation-smartphone .flex-control-paging, .hide-navigation-smartphone .flex-control-nav, .hide-navigation-smartphone .filmstrip{ display: none!important; }}@media only screen and (min-width : 768px) and (max-width: 1023px) {body:after { display: none; content: "tablet"; } .hide-arrows-tablet .flex-direction-nav, .hide-navigation-tablet .flex-control-paging, .hide-navigation-tablet .flex-control-nav, .hide-navigation-tablet .filmstrip{ display: none!important; }}@media only screen and (min-width : 1024px) and (max-width: 1439px) {body:after { display: none; content: "laptop"; } .hide-arrows-laptop .flex-direction-nav, .hide-navigation-laptop .flex-control-paging, .hide-navigation-laptop .flex-control-nav, .hide-navigation-laptop .filmstrip{ display: none!important; }}@media only screen and (min-width : 1440px) {body:after { display: none; content: "desktop"; } .hide-arrows-desktop .flex-direction-nav, .hide-navigation-desktop .flex-control-paging, .hide-navigation-desktop .flex-control-nav, .hide-navigation-desktop .filmstrip{ display: none!important; }}
+</style>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/embed-any-document/js/pdfobject.min.js?ver=2.7.4' id='awsm-ead-pdf-object-js'></script>
+<script type='text/javascript' id='awsm-ead-public-js-extra'>
+/* <![CDATA[ */
+var eadPublic = [];
+/* ]]> */
+</script>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/embed-any-document/js/embed-public.min.js?ver=2.7.4' id='awsm-ead-public-js'></script>
+<script type='text/javascript' id='scroll-back-to-top-js-extra'>
+/* <![CDATA[ */
+var scrollBackToTop = {"scrollDuration":"500","fadeDuration":"0.5"};
+/* ]]> */
+</script>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/scroll-back-to-top/assets/js/scroll-back-to-top.js' id='scroll-back-to-top-js'></script>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri/js/app.min.js?ver=6.2.8' id='habakiri-js'></script>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/ml-slider/assets/sliders/flexslider/jquery.flexslider.min.js?ver=3.93.0' id='metaslider-flex-slider-js'></script>
+<script type='text/javascript' id='metaslider-flex-slider-js-after'>
+var metaslider_38 = function($) {$('#metaslider_38').addClass('flexslider');
+            $('#metaslider_38').flexslider({ 
+                slideshowSpeed:6000,
+                animation:"fade",
+                controlNav:true,
+                directionNav:true,
+                pauseOnHover:true,
+                direction:"horizontal",
+                reverse:false,
+                keyboard:false,
+                touch:true,
+                animationSpeed:2000,
+                prevText:"Previous",
+                nextText:"Next",
+                smoothHeight:false,
+                fadeFirstSlide:false,
+                slideshow:true,
+                pausePlay:false
+            });
+            $(document).trigger('metaslider/initialized', '#metaslider_38');
+        };
+        var timer_metaslider_38 = function() {
+            var slider = !window.jQuery ? window.setTimeout(timer_metaslider_38, 100) : !jQuery.isReady ? window.setTimeout(timer_metaslider_38, 1) : metaslider_38(window.jQuery);
+        };
+        timer_metaslider_38();
+var metaslider_40 = function($) {$('#metaslider_40').addClass('flexslider');
+            $('#metaslider_40').flexslider({ 
+                slideshowSpeed:6000,
+                animation:"fade",
+                controlNav:false,
+                directionNav:false,
+                pauseOnHover:true,
+                direction:"horizontal",
+                reverse:false,
+                keyboard:false,
+                touch:true,
+                animationSpeed:2000,
+                prevText:"Previous",
+                nextText:"Next",
+                smoothHeight:false,
+                fadeFirstSlide:false,
+                slideshow:true,
+                pausePlay:false
+            });
+            $(document).trigger('metaslider/initialized', '#metaslider_40');
+        };
+        var timer_metaslider_40 = function() {
+            var slider = !window.jQuery ? window.setTimeout(timer_metaslider_40, 100) : !jQuery.isReady ? window.setTimeout(timer_metaslider_40, 1) : metaslider_40(window.jQuery);
+        };
+        timer_metaslider_40();
+</script>
+<script type='text/javascript' id='metaslider-script-js-extra'>
+/* <![CDATA[ */
+var wpData = {"baseUrl":"https:\/\/www.keisatsubyoin.or.jp"};
+var wpData = {"baseUrl":"https:\/\/www.keisatsubyoin.or.jp"};
+/* ]]> */
+</script>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/ml-slider/assets/metaslider/script.min.js?ver=3.93.0' id='metaslider-script-js'></script>
+<div id="footerFloatingMenu">
+<ul>
+<li class="ft-tel"><a href="tel:03-5343-5611"><i class="fas fa-phone-volume fa-lg"></i>Call Us</a></li>
+<!--<li class="ft-web"><a href="#" target="_blank"><i class="far fa-calendar-alt"></i>Online Booking</a></li>-->
+<li class="ft-access"><a href="/access/"><i class="fas fa-map-marker-alt"></i>Access</a></li>
+</ul>
+</div>
+<script type="text/javascript" src="https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri-child-1/js-child/jquery.rwdImageMaps.min.js"></script>
+<script>
+//Accordion
+jQuery(function(){
+ 
+    //.accordion1 paragraphs toggle their sibling ul elements when clicked
+jQuery('.accordion1 p').click(function(){
+ 
+jQuery(this).next('ul').slideToggle();
+ 
+});
+});
+//End accordion
+
+//Image map responsiveness
+jQuery(document).ready(function(e) {
+jQuery('img[usemap]').rwdImageMaps()
+});
+//End image map responsiveness
+jQuery(window).on('load', function() {
+var url = jQuery(location).attr('href');
+if(url.indexOf("#") != -1){
+var anchor = url.split("#");
+var target = jQuery('#' + anchor[anchor.length - 1]);
+if(target.length){
+var pos = Math.floor(target.offset().top) - 180;
+jQuery("html, body").animate({scrollTop:pos}, 300);
+}
+}
+});
+
+</script>
+<script>
+jQuery(function() {
+jQuery('.nav-tab > li').on('click',function(){
+jQuery('.nav-tab > li').removeClass('active')
+jQuery(this).addClass('active')
+var index = jQuery('.nav-tab > li').index(this);
+jQuery('#categoryTab > ul').removeClass('show'); 
+jQuery('#categoryTab > ul').eq(index).addClass('show'); 
+});
+});
+</script>
+
+<script>
+(function() {
+  var map = [
+    {prefix: "/", to: "./index.html"},
+    {prefix: "/profile/", to: "./about.html"},
+    {prefix: "/shinryoka/", to: "./departments.html"},
+    {prefix: "/gairai/", to: "./outpatient.html"},
+    {prefix: "/nyuin/", to: "./inpatient.html"},
+    {prefix: "/support/", to: "./support.html"},
+    {prefix: "/access/", to: "./access.html"}
+  ];
+  function remap(u) {
+    var p = u.pathname || "/";
+    var m = map.slice().sort(function(a, b) {
+      return b.prefix.length - a.prefix.length;
+    }).find(function(x) {
+      return p.indexOf(x.prefix) === 0;
+    });
+    return m ? m.to : null;
+  }
+  document.addEventListener('DOMContentLoaded', function() {
+    document.querySelectorAll('a[href]').forEach(function(a) {
+      try {
+        var u = new URL(a.getAttribute('href'), location.href);
+        if (/(^|\.)keisatsubyoin\.or\.jp$/i.test(u.hostname)) {
+          var to = remap(u);
+          if (to) {
+            a.setAttribute('href', to);
+          }
+        }
+      } catch (e) {}
+    });
+  });
+})();
+</script>
+
+</body>
+</html>

--- a/index-en.html
+++ b/index-en.html
@@ -1,0 +1,1176 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en" prefix="og: https://ogp.me/ns#">
+<head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# article: http://ogp.me/ns/article#">
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<link rel="shortcut icon" href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2022/12/favicon.png" />
+<link rel="pingback" href="https://www.keisatsubyoin.or.jp/wordpress/xmlrpc.php" />
+<link href="https://use.fontawesome.com/releases/v5.0.10/css/all.css" rel="stylesheet">
+<link rel="stylesheet" href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri-child-1/css/pageheader-style.css" />
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-VTBF3Q2K4B"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-VTBF3Q2K4B');
+</script>
+<!--[if lt IE 9]>
+<script src="https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri/js/html5shiv.min.js"></script>
+<![endif]-->
+<title>Tokyo Metropolitan Police Hospital | Medical Care That Protects Those You Love | Tokyo Metropolitan Police Hospital in Nakano Ward Welcomes All Community Members</title>
+
+<!-- All in One SEO 4.7.6 - aioseo.com -->
+<meta name="description" content="Medical care that protects those you love | Tokyo Metropolitan Police Hospital in Nakano Ward welcomes anyone in the community." />
+<meta name="robots" content="max-image-preview:large" />
+<meta name="msvalidate.01" content="6025B7F66D63703BEED4E4073634721A" />
+<link rel="canonical" href="https://www.keisatsubyoin.or.jp/" />
+<meta name="generator" content="All in One SEO (AIOSEO) 4.7.6" />
+
+<meta name="google-site-verification" content="97tlZIAoAnOmR7w1s9-GNtXfEEnBRDb7DyN4QJ3Lv3s" />
+<meta property="og:locale" content="en_US" />
+<meta property="og:site_name" content="Tokyo Metropolitan Police Hospital | Medical Care That Protects Those You Love | Tokyo Metropolitan Police Hospital in Nakano Ward Welcomes All Community Members" />
+<meta property="og:type" content="website" />
+<meta property="og:title" content="Tokyo Metropolitan Police Hospital | Medical Care That Protects Those You Love | Tokyo Metropolitan Police Hospital in Nakano Ward Welcomes All Community Members" />
+<meta property="og:description" content="Medical care that protects those you love | Tokyo Metropolitan Police Hospital in Nakano Ward welcomes anyone in the community." />
+<meta property="og:url" content="https://www.keisatsubyoin.or.jp/" />
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content="Tokyo Metropolitan Police Hospital | Medical Care That Protects Those You Love | Tokyo Metropolitan Police Hospital in Nakano Ward Welcomes All Community Members" />
+<meta name="twitter:description" content="Medical care that protects those you love | Tokyo Metropolitan Police Hospital in Nakano Ward welcomes anyone in the community." />
+<script type="application/ld+json" class="aioseo-schema">
+{"@context":"https:\/\/schema.org","@graph":[{"@type":"BreadcrumbList","@id":"https:\/\/www.keisatsubyoin.or.jp\/#breadcrumblist","itemListElement":[{"@type":"ListItem","@id":"https:\/\/www.keisatsubyoin.or.jp\/#listItem","position":1,"name":"Home"}]},{"@type":"Organization","@id":"https:\/\/www.keisatsubyoin.or.jp\/#organization","name":"Tokyo Metropolitan Police Hospital","description":"Medical care that protects those you love | Tokyo Metropolitan Police Hospital in Nakano Ward welcomes anyone in the community.","url":"https:\/\/www.keisatsubyoin.or.jp\/"},{"@type":"WebPage","@id":"https:\/\/www.keisatsubyoin.or.jp\/#webpage","url":"https:\/\/www.keisatsubyoin.or.jp\/","name":"Tokyo Metropolitan Police Hospital | Medical Care That Protects Those You Love | Tokyo Metropolitan Police Hospital in Nakano Ward Welcomes All Community Members","description":"Medical care that protects those you love | Tokyo Metropolitan Police Hospital in Nakano Ward welcomes anyone in the community.","inLanguage":"en","isPartOf":{"@id":"https:\/\/www.keisatsubyoin.or.jp\/#website"},"breadcrumb":{"@id":"https:\/\/www.keisatsubyoin.or.jp\/#breadcrumblist"},"datePublished":"2019-12-03T08:15:37+09:00","dateModified":"2025-05-01T10:08:09+09:00"},{"@type":"WebSite","@id":"https:\/\/www.keisatsubyoin.or.jp\/#website","url":"https:\/\/www.keisatsubyoin.or.jp\/","name":"Tokyo Metropolitan Police Hospital","description":"Medical care that protects those you love | Tokyo Metropolitan Police Hospital in Nakano Ward welcomes anyone in the community.","inLanguage":"en","publisher":{"@id":"https:\/\/www.keisatsubyoin.or.jp\/#organization"},"potentialAction":{"@type":"SearchAction","target":{"@type":"EntryPoint","urlTemplate":"https:\/\/www.keisatsubyoin.or.jp\/?s={search_term_string}"},"query-input":"required name=search_term_string"}}]}
+</script>
+<!-- All in One SEO -->
+
+<link rel='dns-prefetch' href='//netdna.bootstrapcdn.com' />
+<link rel="alternate" type="application/rss+xml" title="Tokyo Metropolitan Police Hospital &raquo; Feed" href="https://www.keisatsubyoin.or.jp/feed/" />
+<script type="text/javascript">
+window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/14.0.0\/72x72\/","ext":".png","svgUrl":"https:\/\/s.w.org\/images\/core\/emoji\/14.0.0\/svg\/","svgExt":".svg","source":{"concatemoji":"https:\/\/www.keisatsubyoin.or.jp\/wordpress\/wp-includes\/js\/wp-emoji-release.min.js?ver=6.2.8"}};
+/*! This file is auto-generated */
+!function(e,a,t){var n,r,o,i=a.createElement("canvas"),p=i.getContext&&i.getContext("2d");function s(e,t){p.clearRect(0,0,i.width,i.height),p.fillText(e,0,0);e=i.toDataURL();return p.clearRect(0,0,i.width,i.height),p.fillText(t,0,0),e===i.toDataURL()}function c(e){var t=a.createElement("script");t.src=e,t.defer=t.type="text/javascript",a.getElementsByTagName("head")[0].appendChild(t)}for(o=Array("flag","emoji"),t.supports={everything:!0,everythingExceptFlag:!0},r=0;r<o.length;r++)t.supports[o[r]]=function(e){if(p&&p.fillText)switch(p.textBaseline="top",p.font="600 32px Arial",e){case"flag":return s("\ud83c\udff3\ufe0f\u200d\u26a7\ufe0f","\ud83c\udff3\ufe0f\u200b\u26a7\ufe0f")?!1:!s("\ud83c\uddfa\ud83c\uddf3","\ud83c\uddfa\u200b\ud83c\uddf3")&&!s("\ud83c\udff4\udb40\udc67\udb40\udc62\udb40\udc65\udb40\udc6e\udb40\udc67\udb40\udc7f","\ud83c\udff4\u200b\udb40\udc67\u200b\udb40\udc62\u200b\udb40\udc65\u200b\udb40\udc6e\u200b\udb40\udc67\u200b\udb40\udc7f");case"emoji":return!s("\ud83e\udef1\ud83c\udffb\u200d\ud83e\udef2\ud83c\udfff","\ud83e\udef1\ud83c\udffb\u200b\ud83e\udef2\ud83c\udfff")}return!1}(o[r]),t.supports.everything=t.supports.everything&&t.supports[o[r]],"flag"!==o[r]&&(t.supports.everythingExceptFlag=t.supports.everythingExceptFlag&&t.supports[o[r]]);t.supports_everythingExceptFlag=t.supports.everythingExceptFlag&&!t.supports.flag,t.DOMReady=!1,t.readyCallback=function(){t.DOMReady=!0},t.supports.everything||(n=function(){t.readyCallback()},a.addEventListener?(a.addEventListener("DOMContentLoaded",n,!1),e.addEventListener("load",n,!1)):(e.attachEvent("onload",n),a.attachEvent("onreadystatechange",function(){"complete"===a.readyState&&t.readyCallback()})),(e=t.source||{}).concatemoji?c(e.concatemoji):e.wpemoji&&e.twemoji&&(c(e.twemoji),c(e.wpemoji)))}(window,document,window._wpemojiSettings);
+</script>
+<style type="text/css">
+img.wp-smiley,
+img.emoji {
+display: inline !important;
+border: none !important;
+box-shadow: none !important;
+height: 1em !important;
+width: 1em !important;
+margin: 0 0.07em !important;
+vertical-align: -0.1em !important;
+background: none !important;
+padding: 0 !important;
+}
+</style>
+<link rel='stylesheet' id='wp-block-library-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-includes/css/dist/block-library/style.min.css?ver=6.2.8' type='text/css' media='all' />
+<style id='pdfemb-pdf-embedder-viewer-style-inline-css' type='text/css'>
+.wp-block-pdfemb-pdf-embedder-viewer{max-width:none}
+
+</style>
+<link rel='stylesheet' id='awsm-ead-public-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/embed-any-document/css/embed-public.min.css?ver=2.7.4' type='text/css' media='all' />
+<link rel='stylesheet' id='classic-theme-styles-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-includes/css/classic-themes.min.css?ver=6.2.8' type='text/css' media='all' />
+<style id='global-styles-inline-css' type='text/css'>
+body{
+--wp--preset--color--black: #000000;
+--wp--preset--color--cyan-bluish-gray: #abb8c3;
+--wp--preset--color--white: #ffffff;
+--wp--preset--color--pale-pink: #f78da7;
+--wp--preset--color--vivid-red: #cf2e2e;
+--wp--preset--color--luminous-vivid-orange: #ff6900;
+--wp--preset--color--luminous-vivid-amber: #fcb900;
+--wp--preset--color--light-green-cyan: #7bdcb5;
+--wp--preset--color--vivid-green-cyan: #00d084;
+--wp--preset--color--pale-cyan-blue: #8ed1fc;
+--wp--preset--color--vivid-cyan-blue: #0693e3;
+--wp--preset--color--vivid-purple: #9b51e0;
+--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%);
+--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan: linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%);
+--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange: linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%);
+--wp--preset--gradient--luminous-vivid-orange-to-vivid-red: linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%);
+--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray: linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%);
+--wp--preset--gradient--cool-to-warm-spectrum: linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186) 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%);
+--wp--preset--gradient--blush-light-purple: linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%);
+--wp--preset--gradient--blush-bordeaux: linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%);
+--wp--preset--gradient--luminous-dusk: linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%);
+--wp--preset--gradient--pale-ocean: linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181) 100%);
+--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128) 0%,rgb(113,206,126) 100%);
+--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%);
+--wp--preset--duotone--dark-grayscale: url('#wp-duotone-dark-grayscale');
+--wp--preset--duotone--grayscale: url('#wp-duotone-grayscale');
+--wp--preset--duotone--purple-yellow: url('#wp-duotone-purple-yellow');
+--wp--preset--duotone--blue-red: url('#wp-duotone-blue-red');
+--wp--preset--duotone--midnight: url('#wp-duotone-midnight');
+--wp--preset--duotone--magenta-yellow: url('#wp-duotone-magenta-yellow');
+--wp--preset--duotone--purple-green: url('#wp-duotone-purple-green');
+--wp--preset--duotone--blue-orange: url('#wp-duotone-blue-orange');
+--wp--preset--font-size--small: 13px;
+--wp--preset--font-size--medium: 20px;
+--wp--preset--font-size--large: 36px;
+--wp--preset--font-size--x-large: 42px;
+--wp--preset--spacing--20: 0.44rem;
+--wp--preset--spacing--30: 0.67rem;
+--wp--preset--spacing--40: 1rem;
+--wp--preset--spacing--50: 1.5rem;
+--wp--preset--spacing--60: 2.25rem;
+--wp--preset--spacing--70: 3.38rem;
+--wp--preset--spacing--80: 5.06rem;
+--wp--preset--shadow--natural: 6px 6px 9px rgba(0, 0, 0, 0.2);
+--wp--preset--shadow--deep: 12px 12px 50px rgba(0, 0, 0, 0.4);
+--wp--preset--shadow--sharp: 6px 6px 0px rgba(0, 0, 0, 0.2);
+--wp--preset--shadow--outlined: 6px 6px 0px -3px rgba(255, 255, 255, 1), 6px 6px rgba(0, 0, 0, 1);
+--wp--preset--shadow--crisp: 6px 6px 0px rgba(0, 0, 0, 1);
+}
+:where(.is-layout-flex){gap: 0.5em;}
+body .is-layout-flow > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}
+body .is-layout-flow > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}
+body .is-layout-flow > .aligncenter{margin-left: auto !important;margin-right: auto !important;}
+body .is-layout-constrained > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}
+body .is-layout-constrained > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}
+body .is-layout-constrained > .aligncenter{margin-left: auto !important;margin-right: auto !important;}
+body .is-layout-constrained > :where(:not(.alignleft):not(.alignright):not(.alignfull)){max-width: var(--wp--style--global--content-size);margin-left: auto !important;margin-right: auto !important;}
+body .is-layout-constrained > .alignwide{max-width: var(--wp--style--global--wide-size);}
+body .is-layout-flex{display: flex;}
+body .is-layout-flex{flex-wrap: wrap;align-items: center;}
+body .is-layout-flex > *{margin: 0;}
+:where(.wp-block-columns.is-layout-flex){gap: 2em;}
+.has-black-color{color: var(--wp--preset--color--black) !important;}
+.has-cyan-bluish-gray-color{color: var(--wp--preset--color--cyan-bluish-gray) !important;}
+.has-white-color{color: var(--wp--preset--color--white) !important;}
+.has-pale-pink-color{color: var(--wp--preset--color--pale-pink) !important;}
+.has-vivid-red-color{color: var(--wp--preset--color--vivid-red) !important;}
+.has-luminous-vivid-orange-color{color: var(--wp--preset--color--luminous-vivid-orange) !important;}
+.has-luminous-vivid-amber-color{color: var(--wp--preset--color--luminous-vivid-amber) !important;}
+.has-light-green-cyan-color{color: var(--wp--preset--color--light-green-cyan) !important;}
+.has-vivid-green-cyan-color{color: var(--wp--preset--color--vivid-green-cyan) !important;}
+.has-pale-cyan-blue-color{color: var(--wp--preset--color--pale-cyan-blue) !important;}
+.has-vivid-cyan-blue-color{color: var(--wp--preset--color--vivid-cyan-blue) !important;}
+.has-vivid-purple-color{color: var(--wp--preset--color--vivid-purple) !important;}
+.has-black-background-color{background-color: var(--wp--preset--color--black) !important;}
+.has-cyan-bluish-gray-background-color{background-color: var(--wp--preset--color--cyan-bluish-gray) !important;}
+.has-white-background-color{background-color: var(--wp--preset--color--white) !important;}
+.has-pale-pink-background-color{background-color: var(--wp--preset--color--pale-pink) !important;}
+.has-vivid-red-background-color{background-color: var(--wp--preset--color--vivid-red) !important;}
+.has-luminous-vivid-orange-background-color{background-color: var(--wp--preset--color--luminous-vivid-orange) !important;}
+.has-luminous-vivid-amber-background-color{background-color: var(--wp--preset--color--luminous-vivid-amber) !important;}
+.has-light-green-cyan-background-color{background-color: var(--wp--preset--color--light-green-cyan) !important;}
+.has-vivid-green-cyan-background-color{background-color: var(--wp--preset--color--vivid-green-cyan) !important;}
+.has-pale-cyan-blue-background-color{background-color: var(--wp--preset--color--pale-cyan-blue) !important;}
+.has-vivid-cyan-blue-background-color{background-color: var(--wp--preset--color--vivid-cyan-blue) !important;}
+.has-vivid-purple-background-color{background-color: var(--wp--preset--color--vivid-purple) !important;}
+.has-black-border-color{border-color: var(--wp--preset--color--black) !important;}
+.has-cyan-bluish-gray-border-color{border-color: var(--wp--preset--color--cyan-bluish-gray) !important;}
+.has-white-border-color{border-color: var(--wp--preset--color--white) !important;}
+.has-pale-pink-border-color{border-color: var(--wp--preset--color--pale-pink) !important;}
+.has-vivid-red-border-color{border-color: var(--wp--preset--color--vivid-red) !important;}
+.has-luminous-vivid-orange-border-color{border-color: var(--wp--preset--color--luminous-vivid-orange) !important;}
+.has-luminous-vivid-amber-border-color{border-color: var(--wp--preset--color--luminous-vivid-amber) !important;}
+.has-light-green-cyan-border-color{border-color: var(--wp--preset--color--light-green-cyan) !important;}
+.has-vivid-green-cyan-border-color{border-color: var(--wp--preset--color--vivid-green-cyan) !important;}
+.has-pale-cyan-blue-border-color{border-color: var(--wp--preset--color--pale-cyan-blue) !important;}
+.has-vivid-cyan-blue-border-color{border-color: var(--wp--preset--color--vivid-cyan-blue) !important;}
+.has-vivid-purple-border-color{border-color: var(--wp--preset--color--vivid-purple) !important;}
+.has-vivid-cyan-blue-to-vivid-purple-gradient-background{background: var(--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple) !important;}
+.has-light-green-cyan-to-vivid-green-cyan-gradient-background{background: var(--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan) !important;}
+.has-luminous-vivid-amber-to-luminous-vivid-orange-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange) !important;}
+.has-luminous-vivid-orange-to-vivid-red-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-orange-to-vivid-red) !important;}
+.has-very-light-gray-to-cyan-bluish-gray-gradient-background{background: var(--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray) !important;}
+.has-cool-to-warm-spectrum-gradient-background{background: var(--wp--preset--gradient--cool-to-warm-spectrum) !important;}
+.has-blush-light-purple-gradient-background{background: var(--wp--preset--gradient--blush-light-purple) !important;}
+.has-blush-bordeaux-gradient-background{background: var(--wp--preset--gradient--blush-bordeaux) !important;}
+.has-luminous-dusk-gradient-background{background: var(--wp--preset--gradient--luminous-dusk) !important;}
+.has-pale-ocean-gradient-background{background: var(--wp--preset--gradient--pale-ocean) !important;}
+.has-electric-grass-gradient-background{background: var(--wp--preset--gradient--electric-grass) !important;}
+.has-midnight-gradient-background{background: var(--wp--preset--gradient--midnight) !important;}
+.has-small-font-size{font-size: var(--wp--preset--font-size--small) !important;}
+.has-medium-font-size{font-size: var(--wp--preset--font-size--medium) !important;}
+.has-large-font-size{font-size: var(--wp--preset--font-size--large) !important;}
+.has-x-large-font-size{font-size: var(--wp--preset--font-size--x-large) !important;}
+.wp-block-navigation a:where(:not(.wp-element-button)){color: inherit;}
+:where(.wp-block-columns.is-layout-flex){gap: 2em;}
+.wp-block-pullquote{font-size: 1.5em;line-height: 1.6;}
+</style>
+<link rel='stylesheet' id='font-awesome-css' href='//netdna.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.css' type='text/css' media='screen' />
+<link rel='stylesheet' id='habakiri-assets-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri/css/assets.min.css?ver=6.2.8' type='text/css' media='all' />
+<link rel='stylesheet' id='habakiri-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri/style.min.css?ver=20250926050751' type='text/css' media='all' />
+<link rel='stylesheet' id='habakiri-child-1-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri-child-1/style.css?ver=20250926050751' type='text/css' media='all' />
+<link rel='stylesheet' id='msl-main-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/master-slider/public/assets/css/masterslider.main.css?ver=3.10.0' type='text/css' media='all' />
+<link rel='stylesheet' id='msl-custom-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/master-slider/custom.css?ver=4.5' type='text/css' media='all' />
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-includes/js/jquery/jquery.min.js?ver=3.6.4' id='jquery-core-js'></script>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-includes/js/jquery/jquery-migrate.min.js?ver=3.4.0' id='jquery-migrate-js'></script>
+<link rel="https://api.w.org/" href="https://www.keisatsubyoin.or.jp/wp-json/" /><link rel="alternate" type="application/json" href="https://www.keisatsubyoin.or.jp/wp-json/wp/v2/pages/22" /><link rel="EditURI" type="application/rsd+xml" title="RSD" href="https://www.keisatsubyoin.or.jp/wordpress/xmlrpc.php?rsd" />
+<link rel="wlwmanifest" type="application/wlwmanifest+xml" href="https://www.keisatsubyoin.or.jp/wordpress/wp-includes/wlwmanifest.xml" />
+<meta name="generator" content="WordPress 6.2.8" />
+<link rel='shortlink' href='https://www.keisatsubyoin.or.jp/' />
+<link rel="alternate" type="application/json+oembed" href="https://www.keisatsubyoin.or.jp/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.keisatsubyoin.or.jp%2F" />
+<link rel="alternate" type="text/xml+oembed" href="https://www.keisatsubyoin.or.jp/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.keisatsubyoin.or.jp%2F&#038;format=xml" />
+<script>var ms_grabbing_curosr = 'https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/master-slider/public/assets/css/common/grabbing.cur', ms_grab_curosr = 'https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/master-slider/public/assets/css/common/grab.cur';</script>
+<meta name="generator" content="MasterSlider 3.10.0 - Responsive Touch Image Slider | avt.li/msf" />
+
+<style>
+.scroll-back-to-top-wrapper {
+    position: fixed;
+opacity: 0;
+visibility: hidden;
+overflow: hidden;
+text-align: center;
+z-index: 99999999;
+    background-color: #777777;
+color: #eeeeee;
+width: 50px;
+height: 48px;
+line-height: 48px;
+right: 30px;
+bottom: 60px;
+padding-top: 2px;
+border-top-left-radius: 10px;
+border-top-right-radius: 10px;
+border-bottom-right-radius: 10px;
+border-bottom-left-radius: 10px;
+-webkit-transition: all 0.5s ease-in-out;
+-moz-transition: all 0.5s ease-in-out;
+-ms-transition: all 0.5s ease-in-out;
+-o-transition: all 0.5s ease-in-out;
+transition: all 0.5s ease-in-out;
+}
+.scroll-back-to-top-wrapper:hover {
+background-color: #888888;
+  color: #eeeeee;
+}
+.scroll-back-to-top-wrapper.show {
+    visibility:visible;
+    cursor:pointer;
+opacity: 1.0;
+}
+.scroll-back-to-top-wrapper i.fa {
+line-height: inherit;
+}
+.scroll-back-to-top-wrapper .fa-lg {
+vertical-align: 0;
+}
+</style><style>
+/* Safari 6.1+ (10.0 is the latest version of Safari at this time) */
+@media (max-width: 991px) and (min-color-index: 0) and (-webkit-min-device-pixel-ratio: 0) { @media () {
+display: block !important;
+.header__col {
+width: 100%;
+}
+}}
+</style>
+<style>a{color:#337ab7}a:focus,a:active,a:hover{color:#23527c}.site-branding a{color:#000}.responsive-nav a{color:#ffffff;font-size:14px}.responsive-nav a small{color:#707070;font-size:10px}.responsive-nav a:hover small,.responsive-nav a:active small,.responsive-nav .current-menu-item small,.responsive-nav .current-menu-ancestor small,.responsive-nav .current-menu-parent small,.responsive-nav .current_page_item small,.responsive-nav .current_page_parent small{color:#707070}.responsive-nav .menu>.menu-item>a,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.menu-item>a{background-color:#f4a000;padding:12px 7px}.responsive-nav .menu>.menu-item>a:hover,.responsive-nav .menu>.menu-item>a:active,.responsive-nav .menu>.current-menu-item>a,.responsive-nav .menu>.current-menu-ancestor>a,.responsive-nav .menu>.current-menu-parent>a,.responsive-nav .menu>.current_page_item>a,.responsive-nav .menu>.current_page_parent>a,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.menu-item>a:hover,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.menu-item>a:active,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.current-menu-item>a,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.current-menu-ancestor>a,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.current-menu-parent>a,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.current_page_item>a,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.current_page_parent>a{background-color:#f5f5f5;color:#707070}.responsive-nav .sub-menu a{background-color:#f5f5f5;color:#707070}.responsive-nav .sub-menu a:hover,.responsive-nav .sub-menu a:active,.responsive-nav .sub-menu .current-menu-item a,.responsive-nav .sub-menu .current-menu-ancestor a,.responsive-nav .sub-menu .current-menu-parent a,.responsive-nav .sub-menu .current_page_item a,.responsive-nav .sub-menu .current_page_parent a{background-color:#f5f5f5;color:#707070}.off-canvas-nav{font-size:12px}.responsive-nav,.header--transparency.header--fixed--is_scrolled .responsive-nav{background-color:#f4a000}#responsive-btn{background-color:transparent;border-color:#eeeeee;color:#000}#responsive-btn:hover{background-color:#f5f5f5;border-color:#eee;color:#000}.habakiri-slider__transparent-layer{background-color:rgba( 0,0,0, 0.1 )}.page-header{background-color:#dddddd;color:#fff}.pagination>li>a{color:#337ab7}.pagination>li>span{background-color:#337ab7;border-color:#337ab7}.pagination>li>a:focus,.pagination>li>a:hover,.pagination>li>span:focus,.pagination>li>span:hover{color:#23527c}.header{background-color:#fff}.header--transparency.header--fixed--is_scrolled{background-color:#fff !important}.footer{background-color:#f49000}.footer-widget-area a{color:#777}.footer-widget-area,.footer-widget-area .widget_calendar #wp-calendar caption{color:#555}.footer-widget-area .widget_calendar #wp-calendar,.footer-widget-area .widget_calendar #wp-calendar *{border-color:#555}@media(min-width:992px){.responsive-nav{display:block}.off-canvas-nav,#responsive-btn{display:none !important}.header--2row{padding-bottom:0}.header--2row .header__col,.header--center .header__col{display:block}.header--2row .responsive-nav,.header--center .responsive-nav{margin-right:-1000px;margin-left:-1000px;padding-right:1000px;padding-left:1000px}.header--center .site-branding{text-align:center}}</style><link rel="icon" href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2022/12/favicon.png" sizes="32x32" />
+<link rel="icon" href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2022/12/favicon.png" sizes="192x192" />
+<link rel="apple-touch-icon" href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2022/12/favicon.png" />
+<meta name="msapplication-TileImage" content="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2022/12/favicon.png" />
+<style type="text/css" id="wp-custom-css">
+.cl_rd {
+color: #F00;
+}
+.responsive-nav .sub-menu a {
+background-color: #f5f5f5;
+color: #707070;
+font-weight:bold
+}
+body{
+  word-wrap : break-word;
+  overflow-wrap : break-word;
+}
+
+img {
+    -webkit-backface-visibility: hidden;
+}
+@media print {
+.scroll-back-to-top-wrapper{
+display: none !important;
+}
+}
+
+.spmenu2 {
+             padding:  10px 0 0;
+    }
+@media screen and (max-width: 991px) {
+    .spmenu {
+       /* border-bottom: solid 1px #ffcf74;*/
+        padding:  0 0 10px;
+width: 100%;
+    }
+}</style>
+</head>
+<body data-rsssl=1 class="home page-template page-template-templates page-template-rich-front-page page-template-templatesrich-front-page-php page page-id-22 _masterslider _ms_version_3.10.0">
+<div id="container">
+<header id="header" class="header header--2row ">
+<div class="container">
+<div class="row header__content">
+<div class="col-xs-10 col-md-12 header__col">
+<div class ="row">
+<div class="col-md-6 col-sm-12">
+
+<div class="site-branding">
+<h1 class="site-branding__heading">
+<a href="./index.html" rel="home"><img src="https://keisatsubyoin.or.jp/wordpress/wp-content/uploads/2020/03/logo.png" alt="Tokyo Metropolitan Police Hospital" class="site-branding__logo" /></a></h1>
+<!-- end .site-branding --></div>
+                        </div>
+<div class="col-md-6 col-sm-12 h-btn-flex">
+<div id="site-cr">
+<a href="./index.html" class="h-btn current">Website for Patients</a>
+<a href="https://www.keisatsubyoin.or.jp/m/" class="h-btn">Website for Healthcare Professionals</a>
+</div>
+                        <ul class="topnav2">
+<li class="f-cv-tel"><i class="fas fa-phone-volume"></i>03-5343-5611<span style="font-size:12px"> (Main)</span><!--<span class="h-time">【Reception Hours】8:00~11:30/12:30~16:00</span>--></li>
+</ul>
+                        </div>
+                 </div>
+         <!-- end .header__col --></div>
+<div class="col-xs-2 col-md-12 header__col global-nav-wrapper clearfix">
+
+<nav class="global-nav js-responsive-nav nav--hide" role="navigation">
+<div class="menu-gnavi-container"><ul id="menu-gnavi" class="menu"><li id="menu-item-35" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-35"><a href="./index.html"><div class="m-icon"><i class="fas fa-home"></i>Home</div></a></li>
+<li id="menu-item-157" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-157"><a href="./outpatient.html"><div class="m-icon"><i class="fas fa-stethoscope"></i>Outpatient Visits</div></a>
+<ul class="sub-menu">
+<li id="menu-item-170" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-170"><a href="./outpatient.html">For First-Time Patients</a></li>
+<li id="menu-item-172" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-172"><a href="./outpatient.html">For Returning Patients</a></li>
+<li id="menu-item-12181" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-12181"><a href="./outpatient.html">About Nighttime &amp; Holiday Clinics</a></li>
+<li id="menu-item-171" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-171"><a href="./outpatient.html">For Patients with Referral Letters</a></li>
+<li id="menu-item-10898" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-10898"><a href="./outpatient.html">About Focused Referral Medical Institutions</a></li>
+<li id="menu-item-169" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-169"><a href="./outpatient.html">Community Primary Care Physicians</a></li>
+<li id="menu-item-158" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-158"><a href="./outpatient.html">About Medications</a></li>
+</ul>
+</li>
+<li id="menu-item-32" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-32"><a href="./departments.html"><div class="m-icon"><i class="fas fa-syringe"></i>Departments &amp; Divisions</div></a></li>
+<li id="menu-item-190" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-190"><a href="./inpatient.html"><div class="m-icon"><i class="fas fa-bed"></i>Inpatient Guide</div></a>
+<ul class="sub-menu">
+<li id="menu-item-194" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-194"><a href="./inpatient.html">Admission &amp; Discharge</a></li>
+<li id="menu-item-191" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-191"><a href="./inpatient.html">For Visitors</a></li>
+<li id="menu-item-193" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-193"><a href="./inpatient.html">Life During Hospitalization</a></li>
+<li id="menu-item-196" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-196"><a href="./inpatient.html">About Patient Rooms</a></li>
+<li id="menu-item-192" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-192"><a href="./inpatient.html">Messages to Inpatients</a></li>
+<li id="menu-item-195" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-195"><a href="./inpatient.html">About DPC</a></li>
+</ul>
+</li>
+<li id="menu-item-332" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-332"><a href="./about.html"><div class="m-icon"><i class="fas fa-hospital-alt"></i>About the Hospital</div></a>
+<ul class="sub-menu">
+<li id="menu-item-330" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-330"><a href="./about.html">Message from the Hospital Director</a></li>
+<li id="menu-item-338" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-338"><a href="./about.html">Overview &amp; History</a></li>
+<li id="menu-item-318" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-318"><a href="./about.html">Philosophy &amp; Core Policies</a></li>
+<li id="menu-item-5336" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-5336"><a href="./about.html">Policy on Refusal of Blood Transfusions</a></li>
+<li id="menu-item-317" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-317"><a href="./about.html">Patients' Rights &amp; Responsibilities</a></li>
+<li id="menu-item-7761" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-7761"><a href="./about.html">Request for Comprehensive Consent</a></li>
+<li id="menu-item-319" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-319"><a href="./about.html">Partnership with Patients</a></li>
+<li id="menu-item-329" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-329"><a href="./about.html">Facility Guide</a></li>
+<li id="menu-item-321" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-321"><a href="./about.html">Professional Accreditations</a></li>
+<li id="menu-item-322" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-322"><a href="./about.html">Advanced Medical Equipment</a></li>
+<li id="menu-item-323" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-323"><a href="./about.html">Accredited Hospital Functions</a></li>
+<li id="menu-item-325" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-325"><a href="./about.html">Tokyo Police Hospital by the Numbers</a></li>
+<li id="menu-item-4097" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4097"><a href="https://www.keisatsubyoin.or.jp/privacy/">Privacy Policy</a></li>
+<li id="menu-item-4098" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4098"><a href="https://www.keisatsubyoin.or.jp/nextgeneration/">Next Generation Development Support Measures</a></li>
+<li id="menu-item-4099" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4099"><a href="https://www.keisatsubyoin.or.jp/josei/">Women's Advancement Promotion Plan</a></li>
+<li id="menu-item-4197" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4197"><a href="./about.html">Notices Required by the Minister of Health, Labour and Welfare</a></li>
+</ul>
+</li>
+<li id="menu-item-357" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-357"><a href="./support.html"><div class="m-icon"><i class="fas fa-comment-dots"></i>Consultation &amp; Support</div></a>
+<ul class="sub-menu">
+<li id="menu-item-364" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-364"><a href="./support.html">Information Desk</a></li>
+<li id="menu-item-365" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-365"><a href="./support.html">About Second Opinions</a></li>
+<li id="menu-item-362" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-362"><a href="./support.html">Nutrition Counseling &amp; Guidance</a></li>
+<li id="menu-item-361" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-361"><a href="./support.html">Medical Social Services</a></li>
+<li id="menu-item-359" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-359"><a href="./support.html">Access to Medical Records</a></li>
+<li id="menu-item-358" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-358"><a href="./support.html">Clinical Support Team</a></li>
+<li id="menu-item-360" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-360"><a href="./support.html">Frequently Asked Questions</a></li>
+<li id="menu-item-363" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-363"><a href="./support.html">Patient Safety</a></li>
+<li id="menu-item-1573" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1573"><a href="./support.html">Telephone Use</a></li>
+<li id="menu-item-4209" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4209"><a href="./support.html">Suggestion Box</a></li>
+<li id="menu-item-1577" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-1577"><a href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2023/03/患者さま図書コーナーのご案内.pdf">Patient Library Corner</a></li>
+<li id="menu-item-4100" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4100"><a href="https://www.keisatsubyoin.or.jp/news_090821_dog/">Assistance Dogs for Persons with Disabilities</a></li>
+<li id="menu-item-4101" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4101"><a href="https://www.keisatsubyoin.or.jp/research/">Clinical Trials &amp; Research</a></li>
+</ul>
+</li>
+<li id="menu-item-31" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-31"><a href="./access.html"><div class="m-icon"><i class="fas fa-map-marker-alt"></i>Access</div></a></li>
+</ul></div><!-- end .global-nav --></nav>
+<div id="responsive-btn"></div>
+</div>
+<!-- end .header__col --></div>
+<!-- end .container --></div>
+<!-- end #header --></header>
+<div id="contents">
+
+<div class="container-fluid">
+<div class="row">
+<main id="main" role="main">
+
+<article class="article article--page post-22 page type-page status-publish">
+<div class="pc"><div id="metaslider-id-38" style="max-width: 1500px; margin: 0 auto;" class="ml-slider-3-93-0 metaslider metaslider-flex metaslider-38 ml-slider ms-theme-default" role="region" aria-roledescription="Slideshow" aria-label="PC">
+    <div id="metaslider_container_38">
+        <div id="metaslider_38">
+            <ul class='slides'>
+                <li style="display: block; width: 100%;" class="slide-39 ms-image " aria-roledescription="slide" aria-label="slide-39"><img src="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2019/12/0001-1500x500.jpg" height="500" width="1500" alt="Hospital exterior" class="slider-38 slide-39" title="Exterior" /></li>
+                <li style="display: none; width: 100%;" class="slide-1288 ms-image " aria-roledescription="slide" aria-label="slide-1288"><img src="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2020/01/0005-1500x500.jpg" height="500" width="1500" alt="General information desk on the first-floor lobby" class="slider-38 slide-1288" title="General Information (1F Lobby)" /></li>
+                <li style="display: none; width: 100%;" class="slide-1286 ms-image " aria-roledescription="slide" aria-label="slide-1286"><img src="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2020/01/0004-1500x500.jpg" height="500" width="1500" alt="Reception and waiting area" class="slider-38 slide-1286" title="Reception &amp; Waiting" /></li>
+                <li style="display: none; width: 100%;" class="slide-1284 ms-image " aria-roledescription="slide" aria-label="slide-1284"><img src="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2020/01/0002-1500x500.jpg" height="500" width="1500" alt="Patient room" class="slider-38 slide-1284" title="Patient Room" /></li>
+            </ul>
+        </div>
+        
+    </div>
+</div><p class="catch"><img src="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2020/03/catch-2.png" alt="Compassionate care that protects those you love"></p>
+</div>
+<div class="sp"><div id="metaslider-id-40" style="max-width: 750px; margin: 0 auto;" class="ml-slider-3-93-0 metaslider metaslider-flex metaslider-40 ml-slider ms-theme-default nav-hidden nav-hidden" role="region" aria-roledescription="Slideshow" aria-label="SP">
+    <div id="metaslider_container_40">
+        <div id="metaslider_40">
+            <ul class='slides'>
+                <li style="display: block; width: 100%;" class="slide-41 ms-image " aria-roledescription="slide" aria-label="slide-41"><img src="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2019/12/sp-0001-625x500.jpg" height="600" width="750" alt="Hospital exterior" class="slider-40 slide-41" title="Exterior" /></li>
+                <li style="display: none; width: 100%;" class="slide-1296 ms-image " aria-roledescription="slide" aria-label="slide-1296"><img src="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2020/01/sp-0005-625x500.jpg" height="600" width="750" alt="General information desk on the first-floor lobby" class="slider-40 slide-1296" title="General Information (1F Lobby)" /></li>
+                <li style="display: none; width: 100%;" class="slide-1295 ms-image " aria-roledescription="slide" aria-label="slide-1295"><img src="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2020/01/sp-0004-625x500.jpg" height="600" width="750" alt="Reception and waiting area" class="slider-40 slide-1295" title="Reception &amp; Waiting" /></li>
+                <li style="display: none; width: 100%;" class="slide-1293 ms-image " aria-roledescription="slide" aria-label="slide-1293"><img src="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2020/01/sp-0002-625x500.jpg" height="600" width="750" alt="Patient room" class="slider-40 slide-1293" title="Patient Room" /></li>
+            </ul>
+        </div>
+        
+    </div>
+</div><p class="catch"><img src="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2020/03/catch-2.png" alt="Compassionate care that protects those you love"></p>
+</div>
+
+<div class="entry">
+<div class="entry__content">
+<div class="container">
+<div class="row">
+<div class="col-md-9">
+<!--
+
+<div class="newsArea">
+
+
+<ul class="newsTabs">
+
+
+<li style="list-style-type: none;">
+
+
+<ul class="newsTabs">
+ 
+
+<li class="newsTab active">Important Notices</li>
+
+
+</ul>
+
+
+</li>
+
+
+</ul>
+
+
+
+
+<ul class="news">
+ 
+
+<li class="tabContent active">[call_php file='news']</li>
+
+
+</ul>
+
+
+<!--
+
+
+<h2>Important Notices</h2>
+
+
+
+
+<ul class="news">
+ 
+
+<li><a href="https://keisatsubyoin.or.jp/wordpress/shinryoka/hihu/doctor.html">Dermatology outpatient service for first-time patients (without referral) temporarily unavailable</a></li>
+
+
+</ul>
+
+
+
+
+</div>
+
+--></p>
+<h2>News from the Hospital</h2>
+<p><!--
+
+<div>
+
+
+<ul class="nav-tab">
+
+
+<li class="active">All</li>
+
+
+
+
+<li>From Departments</li>
+
+
+
+
+<li>From the Hospital</li>
+
+
+
+
+<li>Other</li>
+
+
+</ul>
+
+
+</div>
+
+--></p>
+<div id="categoryTab">
+<ul class="show">
+<li> 
+<a href="https://www.keisatsubyoin.or.jp/%e5%a4%96%e6%9d%a5%e4%bc%91%e8%a8%ba%e6%83%85%e5%a0%b1/"class="newslink">
+<div class="topmeta">
+<div class="news-time">2025/10/03</div>
+<ul class="report-categories">
+<li class="all">
+All</li>
+<li class="med_dep">
+From Departments</li>
+</ul>
+</div>
+<p class="news-title">Outpatient Clinic Closure Information</p>
+</a>
+ 
+ 
+<a href="https://www.keisatsubyoin.or.jp/%e5%a4%96%e6%9d%a5%e6%8b%85%e5%bd%93%e5%8c%bb%e8%a1%a8%e3%82%92%e6%9b%b4%e6%96%b0%e3%81%97%e3%81%be%e3%81%97%e3%81%9f%ef%bc%88%e4%bb%a4%e5%92%8c%ef%bc%97%e5%b9%b4%ef%bc%91%ef%bc%90%e6%9c%88%ef%bc%91/"class="newslink">
+<div class="topmeta">
+<div class="news-time">2025/10/01</div>
+<ul class="report-categories">
+<li class="all">
+All</li>
+<li class="hospital">
+From the Hospital</li>
+</ul>
+</div>
+<p class="news-title">Outpatient Physician Schedule Updated (As of October 1, 2025)</p>
+</a>
+ 
+ 
+<a href="https://www.keisatsubyoin.or.jp/%e5%bd%93%e9%99%a2%e3%83%9b%e3%83%bc%e3%83%a0%e3%83%9a%e3%83%bc%e3%82%b8%e3%81%ae%e3%83%a1%e3%83%b3%e3%83%86%e3%83%8a%e3%83%b3%e3%82%b9%e3%81%ab%e3%81%a4%e3%81%8d%e3%81%be%e3%81%97%e3%81%a6/"class="newslink">
+<div class="topmeta">
+<div class="news-time">2025/09/30</div>
+<ul class="report-categories">
+<li class="all">
+All</li>
+<li class="hospital">
+From the Hospital</li>
+</ul>
+</div>
+<p class="news-title">Notice of Website Maintenance</p>
+</a>
+ 
+ 
+<a href="https://www.keisatsubyoin.or.jp/%e3%82%a4%e3%83%b3%e3%83%95%e3%83%ab%e3%82%a8%e3%83%b3%e3%82%b6%e4%ba%88%e9%98%b2%e6%8e%a5%e7%a8%ae%e3%82%92%e3%81%94%e5%b8%8c%e6%9c%9b%e3%81%ae%e6%96%b9%e3%81%b8/"class="newslink">
+<div class="topmeta">
+<div class="news-time">2025/09/29</div>
+<ul class="report-categories">
+<li class="all">
+All</li>
+<li class="hospital">
+From the Hospital</li>
+</ul>
+</div>
+<p class="news-title">Seasonal Influenza Vaccination Information</p>
+</a>
+ 
+ 
+<a href="https://www.keisatsubyoin.or.jp/%e3%83%9e%e3%82%a4%e3%83%8a%e4%bf%9d%e9%99%ba%e8%a8%bc%e3%81%ae%e3%82%b9%e3%83%9e%e3%83%bc%e3%83%88%e3%83%95%e3%82%a9%e3%83%b3%e5%88%a9%e7%94%a8%e3%81%ab%e3%81%a4%e3%81%8d%e3%81%be%e3%81%97%e3%81%a6/"class="newslink">
+<div class="topmeta">
+<div class="news-time">2025/09/29</div>
+<ul class="report-categories">
+<li class="all">
+All</li>
+<li class="hospital">
+From the Hospital</li>
+</ul>
+</div>
+<p class="news-title">Using My Number Health Insurance Cards on Smartphones</p>
+</a>
+ 
+</li>
+</ul>
+<ul>
+<li> 
+<a href="https://www.keisatsubyoin.or.jp/%e5%a4%96%e6%9d%a5%e4%bc%91%e8%a8%ba%e6%83%85%e5%a0%b1/"class="newslink">
+<div class="topmeta">
+<div class="news-time">2025/10/03</div>
+<ul class="report-categories">
+<li class="all">
+All</li>
+<li class="med_dep">
+From Departments</li>
+</ul>
+</div>
+<p class="news-title">Outpatient Clinic Closure Information</p>
+</a>
+ 
+ 
+<a href="https://www.keisatsubyoin.or.jp/%e7%94%a3%e7%a7%91%e8%a8%ba%e7%99%82%e3%81%ab%e9%96%a2%e3%81%99%e3%82%8b%e3%81%8a%e7%9f%a5%e3%82%89%e3%81%9b/"class="newslink">
+<div class="topmeta">
+<div class="news-time">2024/11/15</div>
+<ul class="report-categories">
+<li class="all">
+All</li>
+<li class="med_dep">
+From Departments</li>
+</ul>
+</div>
+<p class="news-title">Notice Regarding Obstetrics Services</p>
+</a>
+ 
+ 
+<a href="https://www.keisatsubyoin.or.jp/%e3%80%90%e5%a6%8a%e7%94%a3%e5%a9%a6%e3%81%95%e3%82%93%e5%bf%9c%e6%8f%b4%ef%bc%81%e3%80%91%e5%87%ba%e7%94%a3%e8%b2%bb%e7%94%a8%e3%81%ae%e6%94%b9%e5%ae%9a%e3%81%8a%e3%82%88%e3%81%b3%e5%90%84%e7%a8%ae/"class="newslink">
+<div class="topmeta">
+<div class="news-time">2023/10/01</div>
+<ul class="report-categories">
+<li class="all">
+All</li>
+<li class="med_dep">
+From Departments</li>
+</ul>
+</div>
+<p class="news-title">Supporting Expectant Mothers! Updates to Delivery Fees and Services</p>
+</a>
+ 
+ 
+<a href="https://www.keisatsubyoin.or.jp/%e5%bd%93%e9%99%a2%e3%81%a7%e5%88%86%e5%a8%a9%e3%82%92%e3%81%97%e3%81%aa%e3%81%84%e5%a6%8a%e5%a9%a6%e3%81%95%e3%82%93%e3%81%a7%e3%82%82%e3%80%90%e8%83%8e%e5%85%904d%e3%82%a8%e3%82%b3%e3%83%bc%e5%a4%96/"class="newslink">
+<div class="topmeta">
+<div class="news-time">2023/05/30</div>
+<ul class="report-categories">
+<li class="all">
+All</li>
+<li class="med_dep">
+From Departments</li>
+</ul>
+</div>
+<p class="news-title">Fetal 4D Ultrasound Now Available Even for Expectant Mothers Not Delivering with Us</p>
+</a>
+ 
+ 
+<a href="https://www.keisatsubyoin.or.jp/%e3%80%90%e7%b7%8f%e5%90%88%e8%a8%ba%e7%99%82%e5%86%85%e7%a7%91%e3%80%91%e8%a8%ba%e7%99%82%e4%bd%93%e5%88%b6%e3%81%ae%e8%a6%8b%e7%9b%b4%e3%81%97%e3%81%ab%e3%81%a4%e3%81%84%e3%81%a6/"class="newslink">
+<div class="topmeta">
+<div class="news-time">2023/03/15</div>
+<ul class="report-categories">
+<li class="all">
+All</li>
+<li class="med_dep">
+From Departments</li>
+</ul>
+</div>
+<p class="news-title">General Internal Medicine: Update to Clinical Services</p>
+</a>
+ 
+</li>
+</ul>
+<ul>
+<li> 
+<a href="https://www.keisatsubyoin.or.jp/%e5%a4%96%e6%9d%a5%e6%8b%85%e5%bd%93%e5%8c%bb%e8%a1%a8%e3%82%92%e6%9b%b4%e6%96%b0%e3%81%97%e3%81%be%e3%81%97%e3%81%9f%ef%bc%88%e4%bb%a4%e5%92%8c%ef%bc%97%e5%b9%b4%ef%bc%91%ef%bc%90%e6%9c%88%ef%bc%91/"class="newslink">
+<div class="topmeta">
+<div class="news-time">2025/10/01</div>
+<ul class="report-categories">
+<li class="all">
+All</li>
+<li class="hospital">
+From the Hospital</li>
+</ul>
+</div>
+<p class="news-title">Outpatient Physician Schedule Updated (As of October 1, 2025)</p>
+</a>
+ 
+ 
+<a href="https://www.keisatsubyoin.or.jp/%e5%bd%93%e9%99%a2%e3%83%9b%e3%83%bc%e3%83%a0%e3%83%9a%e3%83%bc%e3%82%b8%e3%81%ae%e3%83%a1%e3%83%b3%e3%83%86%e3%83%8a%e3%83%b3%e3%82%b9%e3%81%ab%e3%81%a4%e3%81%8d%e3%81%be%e3%81%97%e3%81%a6/"class="newslink">
+<div class="topmeta">
+<div class="news-time">2025/09/30</div>
+<ul class="report-categories">
+<li class="all">
+All</li>
+<li class="hospital">
+From the Hospital</li>
+</ul>
+</div>
+<p class="news-title">Notice of Website Maintenance</p>
+</a>
+ 
+ 
+<a href="https://www.keisatsubyoin.or.jp/%e3%82%a4%e3%83%b3%e3%83%95%e3%83%ab%e3%82%a8%e3%83%b3%e3%82%b6%e4%ba%88%e9%98%b2%e6%8e%a5%e7%a8%ae%e3%82%92%e3%81%94%e5%b8%8c%e6%9c%9b%e3%81%ae%e6%96%b9%e3%81%b8/"class="newslink">
+<div class="topmeta">
+<div class="news-time">2025/09/29</div>
+<ul class="report-categories">
+<li class="all">
+All</li>
+<li class="hospital">
+From the Hospital</li>
+</ul>
+</div>
+<p class="news-title">Seasonal Influenza Vaccination Information</p>
+</a>
+ 
+ 
+<a href="https://www.keisatsubyoin.or.jp/%e3%83%9e%e3%82%a4%e3%83%8a%e4%bf%9d%e9%99%ba%e8%a8%bc%e3%81%ae%e3%82%b9%e3%83%9e%e3%83%bc%e3%83%88%e3%83%95%e3%82%a9%e3%83%b3%e5%88%a9%e7%94%a8%e3%81%ab%e3%81%a4%e3%81%8d%e3%81%be%e3%81%97%e3%81%a6/"class="newslink">
+<div class="topmeta">
+<div class="news-time">2025/09/29</div>
+<ul class="report-categories">
+<li class="all">
+All</li>
+<li class="hospital">
+From the Hospital</li>
+</ul>
+</div>
+<p class="news-title">Using My Number Health Insurance Cards on Smartphones</p>
+</a>
+ 
+ 
+<a href="https://www.keisatsubyoin.or.jp/%e7%a0%b4%e5%82%b7%e9%a2%a8%e3%83%88%e3%82%ad%e3%82%bd%e3%82%a4%e3%83%89%e3%81%ae%e6%8a%95%e4%b8%8e%e3%81%ae%e4%b8%80%e6%99%82%e4%b8%ad%e6%ad%a2%e3%81%ab%e3%81%a4%e3%81%84%e3%81%a6/"class="newslink">
+<div class="topmeta">
+<div class="news-time">2025/07/25</div>
+<ul class="report-categories">
+<li class="all">
+All</li>
+<li class="hospital">
+From the Hospital</li>
+</ul>
+</div>
+<p class="news-title">Temporary Suspension of Tetanus Toxoid Administration</p>
+</a>
+ 
+</li>
+</ul>
+<ul>
+<li> 
+<a href="https://www.keisatsubyoin.or.jp/%e5%81%a5%e5%ba%b7%e8%ac%9b%e5%ba%a7%e9%96%8b%e5%82%ac%e3%81%ae%e3%81%8a%e7%9f%a5%e3%82%89%e3%81%9b/"class="newslink">
+<div class="topmeta">
+<div class="news-time">2025/09/02</div>
+<ul class="report-categories">
+<li class="all">
+All</li>
+<li class="other">
+Other</li>
+</ul>
+</div>
+<p class="news-title">Notice of Health Seminar</p>
+</a>
+ 
+ 
+<a href="https://www.keisatsubyoin.or.jp/%e5%ba%83%e5%a0%b1%e8%aa%8c%e3%80%8c%e6%9d%b1%e4%ba%ac%e8%ad%a6%e5%af%9f%e7%97%85%e9%99%a2%ef%bd%8e%ef%bd%85%ef%bd%97%ef%bd%93%e3%80%8d%e6%9c%80%e6%96%b0%e5%8f%b7%e3%82%92%e6%9b%b4%e6%96%b0%e3%81%84-2/"class="newslink">
+<div class="topmeta">
+<div class="news-time">2025/08/15</div>
+<ul class="report-categories">
+<li class="all">
+All</li>
+<li class="other">
+Other</li>
+</ul>
+</div>
+<p class="news-title">Hospital Newsletter “Tokyo Police Hospital NEWS” Latest Issue Posted</p>
+</a>
+ 
+ 
+<a href="https://www.keisatsubyoin.or.jp/%e5%81%a5%e5%ba%b7%e8%ac%9b%e5%ba%a7%e5%86%8d%e9%96%8b%e3%81%ae%e3%81%8a%e7%9f%a5%e3%82%89%e3%81%9b/"class="newslink">
+<div class="topmeta">
+<div class="news-time">2025/04/11</div>
+<ul class="report-categories">
+<li class="all">
+All</li>
+<li class="other">
+Other</li>
+</ul>
+</div>
+<p class="news-title">Health Seminars Resuming</p>
+</a>
+ 
+ 
+<a href="https://www.keisatsubyoin.or.jp/%e5%8c%bb%e7%99%82%e6%a4%9c%e7%b4%a2%e3%82%b5%e3%82%a4%e3%83%88%e3%80%8c%e3%83%a1%e3%83%87%e3%82%a3%e3%82%ab%e3%83%ab%e3%83%8e%e3%83%bc%e3%83%88%e3%80%8d%e3%81%ab%e9%95%b7%e8%b0%b7%e5%b7%9d%e9%99%a2/"class="newslink">
+<div class="topmeta">
+<div class="news-time">2025/01/14</div>
+<ul class="report-categories">
+<li class="all">
+All</li>
+<li class="other">
+Other</li>
+</ul>
+</div>
+<p class="news-title">Director Hasegawa Featured on “Medical Note” Healthcare Search Site</p>
+</a>
+ 
+ 
+<a href="https://www.keisatsubyoin.or.jp/%e4%bb%a4%e5%92%8c6%e5%b9%b4%e8%83%bd%e7%99%bb%e5%8d%8a%e5%b3%b6%e5%9c%b0%e9%9c%87%e3%81%ab%e3%81%8a%e3%81%91%e3%82%8b%e7%81%bd%e5%ae%b3%e6%94%af%e6%8f%b4%e6%b4%bb%e5%8b%95/"class="newslink">
+<div class="topmeta">
+<div class="news-time">2024/02/08</div>
+<ul class="report-categories">
+<li class="all">
+All</li>
+<li class="other">
+Other</li>
+</ul>
+</div>
+<p class="news-title">Disaster Relief Activities for the 2024 Noto Peninsula Earthquake</p>
+</a>
+ 
+</li>
+</ul>
+<p align="right">
+<a href="https://keisatsubyoin.or.jp/category/all/" class="s-btn">View All Articles</a>
+</p>
+</div>
+<div class="topBnr">
+<ul>
+<li><a href="./support.html" class="kanzya"><span><i class="fas fa-users"></i></span><i class="fas fa-caret-right"></i> Patients &amp; Community Members</a></li>
+<li><a href="https://keisatsubyoin.or.jp/m/" class="kankeisya"><span><i class="fas fa-user-md"></i></span><i class="fas fa-caret-right"></i> Healthcare Professionals</a></li>
+</ul>
+<ul>
+<li><a href="./departments.html" class="dog"><span><i class="fas fa-clipboard-check"></i></span><i class="fas fa-caret-right"></i> Comprehensive Health Exams</a></li>
+<li><a href="https://keisatsubyoin.or.jp/m/recruit/" class="saiyou"><span><i class="fas fa-search-plus"></i></span><i class="fas fa-caret-right"></i> Careers</a></li>
+</ul>
+</div>
+<p><!--
+
+<ul class="itioshi-bnr">
+ 
+
+<li><a href="/shinryoka/nosmoking/"><img decoding="async" src="https://keisatsubyoin.or.jp/wordpress/wp-content/uploads/2020/01/bnr08nosmoke.gif" alt="" /></a></li>
+
+
+ 
+
+<li><a href="https://keisatsubyoin.or.jp/wordpress/gakko/index.html" target="_blank" rel="noopener noreferrer"><img decoding="async" src="https://keisatsubyoin.or.jp/wordpress/wp-content/uploads/2020/01/bnr07school2.gif" alt="" /></a></li>
+
+
+</ul>
+
+-->
+</div>
+<p><!--col-md-9--></p>
+<div class="col-md-3 sidebar">
+<div class="searchArea">
+<!-- Widget Shortcode --><div id="search-2" class="widget widget_search widget-shortcode area-sidebar ">
+
+<form role="search" method="get" class="search-form" action="https://www.keisatsubyoin.or.jp/">
+<label class="screen-reader-text" for="s">Search:</label>
+<div class="input-group">
+<input type="search" class="form-control" placeholder="Search&hellip;" value="" name="s" title="Search:" />
+<span class="input-group-btn">
+<input type="submit" class="btn btn-default" value="Search" />
+</span>
+</div>
+</form>
+</div><!-- /Widget Shortcode -->
+</div>
+<h3 class="s-h3">Outpatient Reception Hours</h3>
+<h3 class="s-h3Time">8:00&ndash;11:30 / 12:30&ndash;16:00</h3>
+<h3 class="s-h3">Consultation Hours</h3>
+<h3 class="s-h3Time">8:30&ndash;12:00 / 13:00&ndash;16:30</h3>
+<ul>
+<li>Hours vary by department.</li>
+<li>Afternoon visits are by appointment only (except Pediatrics).</li>
+</ul>
+<p class="s-text">*For details, please see the outpatient physician schedule or contact each department.</p>
+<p><a class="s-btn" href="https://keisatsubyoin.or.jp/schedule/" rel="noopener noreferrer"><i class="fas fa-chevron-right"></i>Outpatient Physician Schedule</a><br />
+<a class="s-btn2" href="https://keisatsubyoin.or.jp/wordpress/wp-content/uploads/2022/07/休診情報.pdf" style="margin-top: -30px; text-decoration:none;" rel="noopener noreferrer"><i class="fas fa-chevron-right"></i>Outpatient Closure Notices</a><br />
+</p>
+<h3 class="s-h3">Closed Days</h3>
+<p class="s-text">&bull; Sundays &bull; Public Holidays<br />
+&bull; Year-end/New Year Holidays (12/29&ndash;1/3)</p>
+<p><a class="s-btn3" href="./outpatient.html" style="text-decoration:none;" rel="noopener noreferrer"><i class="fas fa-chevron-right"></i>Nighttime &amp; Holiday Clinics</a></p>
+<p><a class="bnr-sanka"><a href="./departments.html" target="blank" rel="noopener noreferrer"><img decoding="async" src="https://keisatsubyoin.or.jp/wordpress/wp-content/uploads/2020/03/bnr-sanka.png" alt="Obstetrics Guide"  style="margin-top:10px;" /></a></a><br />
+<!--　★かかりつけ医MAP検索★　--><br />
+<a class="bnr-sanka"><a href="https://www.medimap.jp/p131470061/registered/list" target="blank" rel="noopener noreferrer"><img decoding="async" src="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2024/08/bnr_medimap.png" alt="Primary Care Physician Map Search" /></a></a><br />
+<!--　★かかりつけ医MAP検索★　--></p>
+</div>
+<p><!--
+
+<div class="smokeflex">
+
+
+<p class="smokeText">The entire hospital campus is smoke-free. Thank you for your cooperation.</p>
+
+
+
+
+<p class="smokeimg"><img decoding="async" src="https://keisatsubyoin.or.jp/wordpress/wp-content/uploads/2020/03/smoke-2.png"></p>
+
+
+</div>
+
+--><br />
+<!--col-md-3--></p>
+</div>
+<p><!--row--></p>
+</div>
+<!-- end .entry__content --></div>
+<!-- end .entry --></div>
+</article>
+
+<!-- end #main --></main>
+<!-- end .row --></div>
+<!-- end .container-fluid --></div>
+
+<!-- end #contents --></div>
+<footer id="footer" class="footer">
+
+
+<div class="f-menuArea">
+<div class="container">
+<ul class="f-menu">
+<li>
+<div class="spmenu"><i class="fas fa-chevron-right"></i><a href="./outpatient.html">Outpatient Visits</a></div>
+<ul class="f-sub-menu">
+<li><a href="./outpatient.html">For First-Time Patients</a></li>
+<li><a href="./outpatient.html">For Returning Patients</a></li>
+<li><a href="./outpatient.html">Nighttime &amp; Holiday (After-Hours) Clinics</a></li>
+<li><a href="./outpatient.html">For Patients with Referral Letters</a></li>
+<li><a href="./outpatient.html">About Focused Referral Medical Institutions</a></li>
+<li><a href="./outpatient.html">Keep a Community Primary Care Physician</a></li>
+<li><a href="./outpatient.html">About Medications</a></li>
+</ul>
+<div class="spmenu2"><i class="fas fa-chevron-right"></i><a href="./departments.html">Departments &amp; Divisions</a></div>
+</li>
+<li><i class="fas fa-chevron-right"></i><a href="./inpatient.html">Inpatient Guide</a>
+<ul class="f-sub-menu">
+<li><a href="./inpatient.html">About Admission &amp; Discharge</a></li>
+<li><a href="./inpatient.html">For Visitors</a></li>
+<li><a href="./inpatient.html">Life During Hospitalization</a></li>
+<li><a href="./inpatient.html">About Patient Rooms</a></li>
+<li><a href="./inpatient.html">About Messages to Patients</a></li>
+<li><a href="./inpatient.html">About DPC</a></li>
+</ul>
+</li>
+<li><i class="fas fa-chevron-right"></i><a href="./about.html">About the Hospital</a>
+<ul class="f-sub-menu">
+<li><a href="./about.html">Message from the Hospital Director</a></li>
+<li><a href="./about.html">Hospital Overview</a></li>
+<li><a href="./about.html">Philosophy / Core Policies</a></li>
+<li><a href="./about.html">Policy on Refusal of Blood Transfusions</a></li>
+<li><a href="./about.html">Patients' Rights &amp; Responsibilities</a></li>
+<li><a href="./about.html">Request for Comprehensive Consent</a></li>
+<li><a href="./about.html">Partnership with Patients</a></li>
+<!--<li><a href="./about.html">Organization / Committees</a></li>-->
+<li><a href="./about.html">Floor Guide / On-Site Services</a></li>
+<li><a href="./about.html">Professional Accreditations</a></li>
+<li><a href="./about.html">Advanced Medical Equipment</a></li>
+<li><a href="./about.html">Hospital Function Accreditation</a></li>
+<li><a href="./about.html">Tokyo Police Hospital by the Numbers (Clinical Indicators)</a></li>
+<!--<li><a href="./about.html">History</a></li>-->
+<li><a href="https://www.keisatsubyoin.or.jp/privacy/">Privacy Policy</a></li>
+<li><a href="https://www.keisatsubyoin.or.jp/nextgeneration/">Next Generation Development Support Measures</a></li>
+<li><a href="https://www.keisatsubyoin.or.jp/josei/">Women's Advancement Promotion Plan</a></li>
+<li><a href="./about.html">Notices Required by the Minister of Health, Labour and Welfare</a></li>
+<li><a href="https://www.keisatsubyoin.or.jp/sitemap/">Site Map</a></li>
+</ul>
+</li>
+<li><div class="spmenu"><i class="fas fa-chevron-right"></i><a href="./support.html">Consultation &amp; Support</a></div>
+<ul class="f-sub-menu">
+<li><a href="./support.html">Information Desk</a></li>
+<li><a href="./support.html">Second Opinions</a></li>
+<li><a href="./support.html">Meals &amp; Nutrition Guidance</a></li>
+<li><a href="./support.html">Medical Social Services</a></li>
+<li><a href="./support.html">Access to Medical Records</a></li>
+<li><a href="./support.html">Clinical Support</a></li>
+<li><a href="./support.html">Frequently Asked Questions</a></li>
+<li><a href="./support.html">Patient Safety &amp; Infection Control</a></li>
+<li><a href="./support.html">Telephone Use</a></li>
+<li><a href="./support.html">Suggestion Box</a></li>
+<li><a href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2023/03/患者さま図書コーナーのご案内.pdf">Patient Library Corner</a></li>
+<!--<li><a href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2020/02/vol.11_Kanjasama-Tosyo.pdf#page=1&zoom=200">Patient Library Corner</a></li>-->
+<li><a href="https://www.keisatsubyoin.or.jp/news_090821_dog/">Assistance Dogs for Persons with Disabilities</a></li>
+<li><a href="https://www.keisatsubyoin.or.jp/research/">Clinical Trials &amp; Research</a></li>
+</ul>
+<div class="spmenu2"><i class="fas fa-chevron-right"></i><a href="./access.html">Access</a></div>
+</li>
+</ul>
+</div>
+</div>
+<div class="copyright">
+<div class="container">
+&copy; Tokyo Metropolitan Police Hospital 4-22-1 Nakano, Nakano-ku, Tokyo
+<!-- end .container --></div>
+<!-- end .copyright --></div>
+<!-- end #footer --></footer>
+<!-- end #container --></div>
+<div class="scroll-back-to-top-wrapper">
+<span class="scroll-back-to-top-inner">
+<i class="fa fa-2x fa-arrow-circle-up"></i>
+</span>
+</div><script>
+jQuery( function( $ ) {
+$( '.js-responsive-nav' ).responsive_nav( {
+direction: 'right'
+} );
+} );
+</script>
+<link rel='stylesheet' id='metaslider-flex-slider-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/ml-slider/assets/sliders/flexslider/flexslider.css?ver=3.93.0' type='text/css' media='all' property='stylesheet' />
+<link rel='stylesheet' id='metaslider-public-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/ml-slider/assets/metaslider/public.css?ver=3.93.0' type='text/css' media='all' property='stylesheet' />
+<style id='metaslider-public-inline-css' type='text/css'>
+@media only screen and (max-width: 767px) {body:after { display: none; content: "smartphone"; } .hide-arrows-smartphone .flex-direction-nav, .hide-navigation-smartphone .flex-control-paging, .hide-navigation-smartphone .flex-control-nav, .hide-navigation-smartphone .filmstrip{ display: none!important; }}@media only screen and (min-width : 768px) and (max-width: 1023px) {body:after { display: none; content: "tablet"; } .hide-arrows-tablet .flex-direction-nav, .hide-navigation-tablet .flex-control-paging, .hide-navigation-tablet .flex-control-nav, .hide-navigation-tablet .filmstrip{ display: none!important; }}@media only screen and (min-width : 1024px) and (max-width: 1439px) {body:after { display: none; content: "laptop"; } .hide-arrows-laptop .flex-direction-nav, .hide-navigation-laptop .flex-control-paging, .hide-navigation-laptop .flex-control-nav, .hide-navigation-laptop .filmstrip{ display: none!important; }}@media only screen and (min-width : 1440px) {body:after { display: none; content: "desktop"; } .hide-arrows-desktop .flex-direction-nav, .hide-navigation-desktop .flex-control-paging, .hide-navigation-desktop .flex-control-nav, .hide-navigation-desktop .filmstrip{ display: none!important; }}
+@media only screen and (max-width: 767px) {body:after { display: none; content: "smartphone"; } .hide-arrows-smartphone .flex-direction-nav, .hide-navigation-smartphone .flex-control-paging, .hide-navigation-smartphone .flex-control-nav, .hide-navigation-smartphone .filmstrip{ display: none!important; }}@media only screen and (min-width : 768px) and (max-width: 1023px) {body:after { display: none; content: "tablet"; } .hide-arrows-tablet .flex-direction-nav, .hide-navigation-tablet .flex-control-paging, .hide-navigation-tablet .flex-control-nav, .hide-navigation-tablet .filmstrip{ display: none!important; }}@media only screen and (min-width : 1024px) and (max-width: 1439px) {body:after { display: none; content: "laptop"; } .hide-arrows-laptop .flex-direction-nav, .hide-navigation-laptop .flex-control-paging, .hide-navigation-laptop .flex-control-nav, .hide-navigation-laptop .filmstrip{ display: none!important; }}@media only screen and (min-width : 1440px) {body:after { display: none; content: "desktop"; } .hide-arrows-desktop .flex-direction-nav, .hide-navigation-desktop .flex-control-paging, .hide-navigation-desktop .flex-control-nav, .hide-navigation-desktop .filmstrip{ display: none!important; }}
+</style>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/embed-any-document/js/pdfobject.min.js?ver=2.7.4' id='awsm-ead-pdf-object-js'></script>
+<script type='text/javascript' id='awsm-ead-public-js-extra'>
+/* <![CDATA[ */
+var eadPublic = [];
+/* ]]> */
+</script>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/embed-any-document/js/embed-public.min.js?ver=2.7.4' id='awsm-ead-public-js'></script>
+<script type='text/javascript' id='scroll-back-to-top-js-extra'>
+/* <![CDATA[ */
+var scrollBackToTop = {"scrollDuration":"500","fadeDuration":"0.5"};
+/* ]]> */
+</script>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/scroll-back-to-top/assets/js/scroll-back-to-top.js' id='scroll-back-to-top-js'></script>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri/js/app.min.js?ver=6.2.8' id='habakiri-js'></script>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/ml-slider/assets/sliders/flexslider/jquery.flexslider.min.js?ver=3.93.0' id='metaslider-flex-slider-js'></script>
+<script type='text/javascript' id='metaslider-flex-slider-js-after'>
+var metaslider_38 = function($) {$('#metaslider_38').addClass('flexslider');
+            $('#metaslider_38').flexslider({ 
+                slideshowSpeed:6000,
+                animation:"fade",
+                controlNav:true,
+                directionNav:true,
+                pauseOnHover:true,
+                direction:"horizontal",
+                reverse:false,
+                keyboard:false,
+                touch:true,
+                animationSpeed:2000,
+                prevText:"Previous",
+                nextText:"Next",
+                smoothHeight:false,
+                fadeFirstSlide:false,
+                slideshow:true,
+                pausePlay:false
+            });
+            $(document).trigger('metaslider/initialized', '#metaslider_38');
+        };
+        var timer_metaslider_38 = function() {
+            var slider = !window.jQuery ? window.setTimeout(timer_metaslider_38, 100) : !jQuery.isReady ? window.setTimeout(timer_metaslider_38, 1) : metaslider_38(window.jQuery);
+        };
+        timer_metaslider_38();
+var metaslider_40 = function($) {$('#metaslider_40').addClass('flexslider');
+            $('#metaslider_40').flexslider({ 
+                slideshowSpeed:6000,
+                animation:"fade",
+                controlNav:false,
+                directionNav:false,
+                pauseOnHover:true,
+                direction:"horizontal",
+                reverse:false,
+                keyboard:false,
+                touch:true,
+                animationSpeed:2000,
+                prevText:"Previous",
+                nextText:"Next",
+                smoothHeight:false,
+                fadeFirstSlide:false,
+                slideshow:true,
+                pausePlay:false
+            });
+            $(document).trigger('metaslider/initialized', '#metaslider_40');
+        };
+        var timer_metaslider_40 = function() {
+            var slider = !window.jQuery ? window.setTimeout(timer_metaslider_40, 100) : !jQuery.isReady ? window.setTimeout(timer_metaslider_40, 1) : metaslider_40(window.jQuery);
+        };
+        timer_metaslider_40();
+</script>
+<script type='text/javascript' id='metaslider-script-js-extra'>
+/* <![CDATA[ */
+var wpData = {"baseUrl":"https:\/\/www.keisatsubyoin.or.jp"};
+var wpData = {"baseUrl":"https:\/\/www.keisatsubyoin.or.jp"};
+/* ]]> */
+</script>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/ml-slider/assets/metaslider/script.min.js?ver=3.93.0' id='metaslider-script-js'></script>
+<div id="footerFloatingMenu">
+<ul>
+<li class="ft-tel"><a href="tel:03-5343-5611"><i class="fas fa-phone-volume fa-lg"></i>Call Us</a></li>
+<!--<li class="ft-web"><a href="#" target="_blank"><i class="far fa-calendar-alt"></i>Online Booking</a></li>-->
+<li class="ft-access"><a href="/access/"><i class="fas fa-map-marker-alt"></i>Access</a></li>
+</ul>
+</div>
+<script type="text/javascript" src="https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri-child-1/js-child/jquery.rwdImageMaps.min.js"></script>
+<script>
+//Accordion
+jQuery(function(){
+ 
+    //.accordion1 paragraphs toggle their sibling ul elements when clicked
+jQuery('.accordion1 p').click(function(){
+ 
+jQuery(this).next('ul').slideToggle();
+ 
+});
+});
+//End accordion
+
+//Image map responsiveness
+jQuery(document).ready(function(e) {
+jQuery('img[usemap]').rwdImageMaps()
+});
+//End image map responsiveness
+jQuery(window).on('load', function() {
+var url = jQuery(location).attr('href');
+if(url.indexOf("#") != -1){
+var anchor = url.split("#");
+var target = jQuery('#' + anchor[anchor.length - 1]);
+if(target.length){
+var pos = Math.floor(target.offset().top) - 180;
+jQuery("html, body").animate({scrollTop:pos}, 300);
+}
+}
+});
+
+</script>
+<script>
+jQuery(function() {
+jQuery('.nav-tab > li').on('click',function(){
+jQuery('.nav-tab > li').removeClass('active')
+jQuery(this).addClass('active')
+var index = jQuery('.nav-tab > li').index(this);
+jQuery('#categoryTab > ul').removeClass('show'); 
+jQuery('#categoryTab > ul').eq(index).addClass('show'); 
+});
+});
+</script>
+
+<script>
+(function() {
+  var map = [
+    {prefix: "/", to: "./index.html"},
+    {prefix: "/profile/", to: "./about.html"},
+    {prefix: "/shinryoka/", to: "./departments.html"},
+    {prefix: "/gairai/", to: "./outpatient.html"},
+    {prefix: "/nyuin/", to: "./inpatient.html"},
+    {prefix: "/support/", to: "./support.html"},
+    {prefix: "/access/", to: "./access.html"}
+  ];
+  function remap(u) {
+    var p = u.pathname || "/";
+    var m = map.slice().sort(function(a, b) {
+      return b.prefix.length - a.prefix.length;
+    }).find(function(x) {
+      return p.indexOf(x.prefix) === 0;
+    });
+    return m ? m.to : null;
+  }
+  document.addEventListener('DOMContentLoaded', function() {
+    document.querySelectorAll('a[href]').forEach(function(a) {
+      try {
+        var u = new URL(a.getAttribute('href'), location.href);
+        if (/(^|\.)keisatsubyoin\.or\.jp$/i.test(u.hostname)) {
+          var to = remap(u);
+          if (to) {
+            a.setAttribute('href', to);
+          }
+        }
+      } catch (e) {}
+    });
+  });
+})();
+</script>
+
+</body>
+</html>

--- a/inpatient.html
+++ b/inpatient.html
@@ -1,0 +1,659 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en" prefix="og: https://ogp.me/ns#">
+<head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# article: http://ogp.me/ns/article#">
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<link rel="shortcut icon" href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2022/12/favicon.png" />
+<link rel="pingback" href="https://www.keisatsubyoin.or.jp/wordpress/xmlrpc.php" />
+<link href="https://use.fontawesome.com/releases/v5.0.10/css/all.css" rel="stylesheet">
+<link rel="stylesheet" href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri-child-1/css/pageheader-style.css" />
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-VTBF3Q2K4B"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-VTBF3Q2K4B');
+</script>
+<!--[if lt IE 9]>
+<script src="https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri/js/html5shiv.min.js"></script>
+<![endif]-->
+<title>Inpatient Guide | Tokyo Metropolitan Police Hospital</title>
+
+<!-- All in One SEO 4.7.6 - aioseo.com -->
+<meta name="description" content="Content coming soon." />
+<meta name="robots" content="max-image-preview:large" />
+<meta name="msvalidate.01" content="6025B7F66D63703BEED4E4073634721A" />
+<link rel="canonical" href="./inpatient.html" />
+<meta name="generator" content="All in One SEO (AIOSEO) 4.7.6" />
+
+<meta name="google-site-verification" content="97tlZIAoAnOmR7w1s9-GNtXfEEnBRDb7DyN4QJ3Lv3s" />
+<meta property="og:locale" content="en_US" />
+<meta property="og:site_name" content="Tokyo Metropolitan Police Hospital | Medical Care That Protects Those You Love | Tokyo Metropolitan Police Hospital in Nakano Ward Welcomes All Community Members" />
+<meta property="og:type" content="website" />
+<meta property="og:title" content="Inpatient Guide | Tokyo Metropolitan Police Hospital" />
+<meta property="og:description" content="Medical care that protects those you love | Tokyo Metropolitan Police Hospital in Nakano Ward welcomes anyone in the community." />
+<meta property="og:url" content="./inpatient.html" />
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content="Inpatient Guide | Tokyo Metropolitan Police Hospital" />
+<meta name="twitter:description" content="Content coming soon." />
+<script type="application/ld+json" class="aioseo-schema">
+{"@context":"https:\/\/schema.org","@graph":[{"@type":"BreadcrumbList","@id":"https:\/\/www.keisatsubyoin.or.jp\/#breadcrumblist","itemListElement":[{"@type":"ListItem","@id":"https:\/\/www.keisatsubyoin.or.jp\/#listItem","position":1,"name":"Home"}]},{"@type":"Organization","@id":"https:\/\/www.keisatsubyoin.or.jp\/#organization","name":"Tokyo Metropolitan Police Hospital","description":"Medical care that protects those you love | Tokyo Metropolitan Police Hospital in Nakano Ward welcomes anyone in the community.","url":"https:\/\/www.keisatsubyoin.or.jp\/"},{"@type":"WebPage","@id":"https:\/\/www.keisatsubyoin.or.jp\/#webpage","url":"https:\/\/www.keisatsubyoin.or.jp\/","name":"Tokyo Metropolitan Police Hospital | Medical Care That Protects Those You Love | Tokyo Metropolitan Police Hospital in Nakano Ward Welcomes All Community Members","description":"Medical care that protects those you love | Tokyo Metropolitan Police Hospital in Nakano Ward welcomes anyone in the community.","inLanguage":"en","isPartOf":{"@id":"https:\/\/www.keisatsubyoin.or.jp\/#website"},"breadcrumb":{"@id":"https:\/\/www.keisatsubyoin.or.jp\/#breadcrumblist"},"datePublished":"2019-12-03T08:15:37+09:00","dateModified":"2025-05-01T10:08:09+09:00"},{"@type":"WebSite","@id":"https:\/\/www.keisatsubyoin.or.jp\/#website","url":"https:\/\/www.keisatsubyoin.or.jp\/","name":"Tokyo Metropolitan Police Hospital","description":"Medical care that protects those you love | Tokyo Metropolitan Police Hospital in Nakano Ward welcomes anyone in the community.","inLanguage":"en","publisher":{"@id":"https:\/\/www.keisatsubyoin.or.jp\/#organization"},"potentialAction":{"@type":"SearchAction","target":{"@type":"EntryPoint","urlTemplate":"https:\/\/www.keisatsubyoin.or.jp\/?s={search_term_string}"},"query-input":"required name=search_term_string"}}]}
+</script>
+<!-- All in One SEO -->
+
+<link rel='dns-prefetch' href='//netdna.bootstrapcdn.com' />
+<link rel="alternate" type="application/rss+xml" title="Tokyo Metropolitan Police Hospital &raquo; Feed" href="https://www.keisatsubyoin.or.jp/feed/" />
+<script type="text/javascript">
+window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/14.0.0\/72x72\/","ext":".png","svgUrl":"https:\/\/s.w.org\/images\/core\/emoji\/14.0.0\/svg\/","svgExt":".svg","source":{"concatemoji":"https:\/\/www.keisatsubyoin.or.jp\/wordpress\/wp-includes\/js\/wp-emoji-release.min.js?ver=6.2.8"}};
+/*! This file is auto-generated */
+!function(e,a,t){var n,r,o,i=a.createElement("canvas"),p=i.getContext&&i.getContext("2d");function s(e,t){p.clearRect(0,0,i.width,i.height),p.fillText(e,0,0);e=i.toDataURL();return p.clearRect(0,0,i.width,i.height),p.fillText(t,0,0),e===i.toDataURL()}function c(e){var t=a.createElement("script");t.src=e,t.defer=t.type="text/javascript",a.getElementsByTagName("head")[0].appendChild(t)}for(o=Array("flag","emoji"),t.supports={everything:!0,everythingExceptFlag:!0},r=0;r<o.length;r++)t.supports[o[r]]=function(e){if(p&&p.fillText)switch(p.textBaseline="top",p.font="600 32px Arial",e){case"flag":return s("\ud83c\udff3\ufe0f\u200d\u26a7\ufe0f","\ud83c\udff3\ufe0f\u200b\u26a7\ufe0f")?!1:!s("\ud83c\uddfa\ud83c\uddf3","\ud83c\uddfa\u200b\ud83c\uddf3")&&!s("\ud83c\udff4\udb40\udc67\udb40\udc62\udb40\udc65\udb40\udc6e\udb40\udc67\udb40\udc7f","\ud83c\udff4\u200b\udb40\udc67\u200b\udb40\udc62\u200b\udb40\udc65\u200b\udb40\udc6e\u200b\udb40\udc67\u200b\udb40\udc7f");case"emoji":return!s("\ud83e\udef1\ud83c\udffb\u200d\ud83e\udef2\ud83c\udfff","\ud83e\udef1\ud83c\udffb\u200b\ud83e\udef2\ud83c\udfff")}return!1}(o[r]),t.supports.everything=t.supports.everything&&t.supports[o[r]],"flag"!==o[r]&&(t.supports.everythingExceptFlag=t.supports.everythingExceptFlag&&t.supports[o[r]]);t.supports_everythingExceptFlag=t.supports.everythingExceptFlag&&!t.supports.flag,t.DOMReady=!1,t.readyCallback=function(){t.DOMReady=!0},t.supports.everything||(n=function(){t.readyCallback()},a.addEventListener?(a.addEventListener("DOMContentLoaded",n,!1),e.addEventListener("load",n,!1)):(e.attachEvent("onload",n),a.attachEvent("onreadystatechange",function(){"complete"===a.readyState&&t.readyCallback()})),(e=t.source||{}).concatemoji?c(e.concatemoji):e.wpemoji&&e.twemoji&&(c(e.twemoji),c(e.wpemoji)))}(window,document,window._wpemojiSettings);
+</script>
+<style type="text/css">
+img.wp-smiley,
+img.emoji {
+display: inline !important;
+border: none !important;
+box-shadow: none !important;
+height: 1em !important;
+width: 1em !important;
+margin: 0 0.07em !important;
+vertical-align: -0.1em !important;
+background: none !important;
+padding: 0 !important;
+}
+</style>
+<link rel='stylesheet' id='wp-block-library-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-includes/css/dist/block-library/style.min.css?ver=6.2.8' type='text/css' media='all' />
+<style id='pdfemb-pdf-embedder-viewer-style-inline-css' type='text/css'>
+.wp-block-pdfemb-pdf-embedder-viewer{max-width:none}
+
+</style>
+<link rel='stylesheet' id='awsm-ead-public-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/embed-any-document/css/embed-public.min.css?ver=2.7.4' type='text/css' media='all' />
+<link rel='stylesheet' id='classic-theme-styles-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-includes/css/classic-themes.min.css?ver=6.2.8' type='text/css' media='all' />
+<style id='global-styles-inline-css' type='text/css'>
+body{
+--wp--preset--color--black: #000000;
+--wp--preset--color--cyan-bluish-gray: #abb8c3;
+--wp--preset--color--white: #ffffff;
+--wp--preset--color--pale-pink: #f78da7;
+--wp--preset--color--vivid-red: #cf2e2e;
+--wp--preset--color--luminous-vivid-orange: #ff6900;
+--wp--preset--color--luminous-vivid-amber: #fcb900;
+--wp--preset--color--light-green-cyan: #7bdcb5;
+--wp--preset--color--vivid-green-cyan: #00d084;
+--wp--preset--color--pale-cyan-blue: #8ed1fc;
+--wp--preset--color--vivid-cyan-blue: #0693e3;
+--wp--preset--color--vivid-purple: #9b51e0;
+--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%);
+--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan: linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%);
+--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange: linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%);
+--wp--preset--gradient--luminous-vivid-orange-to-vivid-red: linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%);
+--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray: linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%);
+--wp--preset--gradient--cool-to-warm-spectrum: linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186) 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%);
+--wp--preset--gradient--blush-light-purple: linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%);
+--wp--preset--gradient--blush-bordeaux: linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%);
+--wp--preset--gradient--luminous-dusk: linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%);
+--wp--preset--gradient--pale-ocean: linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181) 100%);
+--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128) 0%,rgb(113,206,126) 100%);
+--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%);
+--wp--preset--duotone--dark-grayscale: url('#wp-duotone-dark-grayscale');
+--wp--preset--duotone--grayscale: url('#wp-duotone-grayscale');
+--wp--preset--duotone--purple-yellow: url('#wp-duotone-purple-yellow');
+--wp--preset--duotone--blue-red: url('#wp-duotone-blue-red');
+--wp--preset--duotone--midnight: url('#wp-duotone-midnight');
+--wp--preset--duotone--magenta-yellow: url('#wp-duotone-magenta-yellow');
+--wp--preset--duotone--purple-green: url('#wp-duotone-purple-green');
+--wp--preset--duotone--blue-orange: url('#wp-duotone-blue-orange');
+--wp--preset--font-size--small: 13px;
+--wp--preset--font-size--medium: 20px;
+--wp--preset--font-size--large: 36px;
+--wp--preset--font-size--x-large: 42px;
+--wp--preset--spacing--20: 0.44rem;
+--wp--preset--spacing--30: 0.67rem;
+--wp--preset--spacing--40: 1rem;
+--wp--preset--spacing--50: 1.5rem;
+--wp--preset--spacing--60: 2.25rem;
+--wp--preset--spacing--70: 3.38rem;
+--wp--preset--spacing--80: 5.06rem;
+--wp--preset--shadow--natural: 6px 6px 9px rgba(0, 0, 0, 0.2);
+--wp--preset--shadow--deep: 12px 12px 50px rgba(0, 0, 0, 0.4);
+--wp--preset--shadow--sharp: 6px 6px 0px rgba(0, 0, 0, 0.2);
+--wp--preset--shadow--outlined: 6px 6px 0px -3px rgba(255, 255, 255, 1), 6px 6px rgba(0, 0, 0, 1);
+--wp--preset--shadow--crisp: 6px 6px 0px rgba(0, 0, 0, 1);
+}
+:where(.is-layout-flex){gap: 0.5em;}
+body .is-layout-flow > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}
+body .is-layout-flow > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}
+body .is-layout-flow > .aligncenter{margin-left: auto !important;margin-right: auto !important;}
+body .is-layout-constrained > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}
+body .is-layout-constrained > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}
+body .is-layout-constrained > .aligncenter{margin-left: auto !important;margin-right: auto !important;}
+body .is-layout-constrained > :where(:not(.alignleft):not(.alignright):not(.alignfull)){max-width: var(--wp--style--global--content-size);margin-left: auto !important;margin-right: auto !important;}
+body .is-layout-constrained > .alignwide{max-width: var(--wp--style--global--wide-size);}
+body .is-layout-flex{display: flex;}
+body .is-layout-flex{flex-wrap: wrap;align-items: center;}
+body .is-layout-flex > *{margin: 0;}
+:where(.wp-block-columns.is-layout-flex){gap: 2em;}
+.has-black-color{color: var(--wp--preset--color--black) !important;}
+.has-cyan-bluish-gray-color{color: var(--wp--preset--color--cyan-bluish-gray) !important;}
+.has-white-color{color: var(--wp--preset--color--white) !important;}
+.has-pale-pink-color{color: var(--wp--preset--color--pale-pink) !important;}
+.has-vivid-red-color{color: var(--wp--preset--color--vivid-red) !important;}
+.has-luminous-vivid-orange-color{color: var(--wp--preset--color--luminous-vivid-orange) !important;}
+.has-luminous-vivid-amber-color{color: var(--wp--preset--color--luminous-vivid-amber) !important;}
+.has-light-green-cyan-color{color: var(--wp--preset--color--light-green-cyan) !important;}
+.has-vivid-green-cyan-color{color: var(--wp--preset--color--vivid-green-cyan) !important;}
+.has-pale-cyan-blue-color{color: var(--wp--preset--color--pale-cyan-blue) !important;}
+.has-vivid-cyan-blue-color{color: var(--wp--preset--color--vivid-cyan-blue) !important;}
+.has-vivid-purple-color{color: var(--wp--preset--color--vivid-purple) !important;}
+.has-black-background-color{background-color: var(--wp--preset--color--black) !important;}
+.has-cyan-bluish-gray-background-color{background-color: var(--wp--preset--color--cyan-bluish-gray) !important;}
+.has-white-background-color{background-color: var(--wp--preset--color--white) !important;}
+.has-pale-pink-background-color{background-color: var(--wp--preset--color--pale-pink) !important;}
+.has-vivid-red-background-color{background-color: var(--wp--preset--color--vivid-red) !important;}
+.has-luminous-vivid-orange-background-color{background-color: var(--wp--preset--color--luminous-vivid-orange) !important;}
+.has-luminous-vivid-amber-background-color{background-color: var(--wp--preset--color--luminous-vivid-amber) !important;}
+.has-light-green-cyan-background-color{background-color: var(--wp--preset--color--light-green-cyan) !important;}
+.has-vivid-green-cyan-background-color{background-color: var(--wp--preset--color--vivid-green-cyan) !important;}
+.has-pale-cyan-blue-background-color{background-color: var(--wp--preset--color--pale-cyan-blue) !important;}
+.has-vivid-cyan-blue-background-color{background-color: var(--wp--preset--color--vivid-cyan-blue) !important;}
+.has-vivid-purple-background-color{background-color: var(--wp--preset--color--vivid-purple) !important;}
+.has-black-border-color{border-color: var(--wp--preset--color--black) !important;}
+.has-cyan-bluish-gray-border-color{border-color: var(--wp--preset--color--cyan-bluish-gray) !important;}
+.has-white-border-color{border-color: var(--wp--preset--color--white) !important;}
+.has-pale-pink-border-color{border-color: var(--wp--preset--color--pale-pink) !important;}
+.has-vivid-red-border-color{border-color: var(--wp--preset--color--vivid-red) !important;}
+.has-luminous-vivid-orange-border-color{border-color: var(--wp--preset--color--luminous-vivid-orange) !important;}
+.has-luminous-vivid-amber-border-color{border-color: var(--wp--preset--color--luminous-vivid-amber) !important;}
+.has-light-green-cyan-border-color{border-color: var(--wp--preset--color--light-green-cyan) !important;}
+.has-vivid-green-cyan-border-color{border-color: var(--wp--preset--color--vivid-green-cyan) !important;}
+.has-pale-cyan-blue-border-color{border-color: var(--wp--preset--color--pale-cyan-blue) !important;}
+.has-vivid-cyan-blue-border-color{border-color: var(--wp--preset--color--vivid-cyan-blue) !important;}
+.has-vivid-purple-border-color{border-color: var(--wp--preset--color--vivid-purple) !important;}
+.has-vivid-cyan-blue-to-vivid-purple-gradient-background{background: var(--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple) !important;}
+.has-light-green-cyan-to-vivid-green-cyan-gradient-background{background: var(--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan) !important;}
+.has-luminous-vivid-amber-to-luminous-vivid-orange-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange) !important;}
+.has-luminous-vivid-orange-to-vivid-red-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-orange-to-vivid-red) !important;}
+.has-very-light-gray-to-cyan-bluish-gray-gradient-background{background: var(--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray) !important;}
+.has-cool-to-warm-spectrum-gradient-background{background: var(--wp--preset--gradient--cool-to-warm-spectrum) !important;}
+.has-blush-light-purple-gradient-background{background: var(--wp--preset--gradient--blush-light-purple) !important;}
+.has-blush-bordeaux-gradient-background{background: var(--wp--preset--gradient--blush-bordeaux) !important;}
+.has-luminous-dusk-gradient-background{background: var(--wp--preset--gradient--luminous-dusk) !important;}
+.has-pale-ocean-gradient-background{background: var(--wp--preset--gradient--pale-ocean) !important;}
+.has-electric-grass-gradient-background{background: var(--wp--preset--gradient--electric-grass) !important;}
+.has-midnight-gradient-background{background: var(--wp--preset--gradient--midnight) !important;}
+.has-small-font-size{font-size: var(--wp--preset--font-size--small) !important;}
+.has-medium-font-size{font-size: var(--wp--preset--font-size--medium) !important;}
+.has-large-font-size{font-size: var(--wp--preset--font-size--large) !important;}
+.has-x-large-font-size{font-size: var(--wp--preset--font-size--x-large) !important;}
+.wp-block-navigation a:where(:not(.wp-element-button)){color: inherit;}
+:where(.wp-block-columns.is-layout-flex){gap: 2em;}
+.wp-block-pullquote{font-size: 1.5em;line-height: 1.6;}
+</style>
+<link rel='stylesheet' id='font-awesome-css' href='//netdna.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.css' type='text/css' media='screen' />
+<link rel='stylesheet' id='habakiri-assets-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri/css/assets.min.css?ver=6.2.8' type='text/css' media='all' />
+<link rel='stylesheet' id='habakiri-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri/style.min.css?ver=20250926050751' type='text/css' media='all' />
+<link rel='stylesheet' id='habakiri-child-1-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri-child-1/style.css?ver=20250926050751' type='text/css' media='all' />
+<link rel='stylesheet' id='msl-main-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/master-slider/public/assets/css/masterslider.main.css?ver=3.10.0' type='text/css' media='all' />
+<link rel='stylesheet' id='msl-custom-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/master-slider/custom.css?ver=4.5' type='text/css' media='all' />
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-includes/js/jquery/jquery.min.js?ver=3.6.4' id='jquery-core-js'></script>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-includes/js/jquery/jquery-migrate.min.js?ver=3.4.0' id='jquery-migrate-js'></script>
+<link rel="https://api.w.org/" href="https://www.keisatsubyoin.or.jp/wp-json/" /><link rel="alternate" type="application/json" href="https://www.keisatsubyoin.or.jp/wp-json/wp/v2/pages/22" /><link rel="EditURI" type="application/rsd+xml" title="RSD" href="https://www.keisatsubyoin.or.jp/wordpress/xmlrpc.php?rsd" />
+<link rel="wlwmanifest" type="application/wlwmanifest+xml" href="https://www.keisatsubyoin.or.jp/wordpress/wp-includes/wlwmanifest.xml" />
+<meta name="generator" content="WordPress 6.2.8" />
+<link rel='shortlink' href='https://www.keisatsubyoin.or.jp/' />
+<link rel="alternate" type="application/json+oembed" href="https://www.keisatsubyoin.or.jp/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.keisatsubyoin.or.jp%2F" />
+<link rel="alternate" type="text/xml+oembed" href="https://www.keisatsubyoin.or.jp/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.keisatsubyoin.or.jp%2F&#038;format=xml" />
+<script>var ms_grabbing_curosr = 'https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/master-slider/public/assets/css/common/grabbing.cur', ms_grab_curosr = 'https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/master-slider/public/assets/css/common/grab.cur';</script>
+<meta name="generator" content="MasterSlider 3.10.0 - Responsive Touch Image Slider | avt.li/msf" />
+
+<style>
+.scroll-back-to-top-wrapper {
+    position: fixed;
+opacity: 0;
+visibility: hidden;
+overflow: hidden;
+text-align: center;
+z-index: 99999999;
+    background-color: #777777;
+color: #eeeeee;
+width: 50px;
+height: 48px;
+line-height: 48px;
+right: 30px;
+bottom: 60px;
+padding-top: 2px;
+border-top-left-radius: 10px;
+border-top-right-radius: 10px;
+border-bottom-right-radius: 10px;
+border-bottom-left-radius: 10px;
+-webkit-transition: all 0.5s ease-in-out;
+-moz-transition: all 0.5s ease-in-out;
+-ms-transition: all 0.5s ease-in-out;
+-o-transition: all 0.5s ease-in-out;
+transition: all 0.5s ease-in-out;
+}
+.scroll-back-to-top-wrapper:hover {
+background-color: #888888;
+  color: #eeeeee;
+}
+.scroll-back-to-top-wrapper.show {
+    visibility:visible;
+    cursor:pointer;
+opacity: 1.0;
+}
+.scroll-back-to-top-wrapper i.fa {
+line-height: inherit;
+}
+.scroll-back-to-top-wrapper .fa-lg {
+vertical-align: 0;
+}
+</style><style>
+/* Safari 6.1+ (10.0 is the latest version of Safari at this time) */
+@media (max-width: 991px) and (min-color-index: 0) and (-webkit-min-device-pixel-ratio: 0) { @media () {
+display: block !important;
+.header__col {
+width: 100%;
+}
+}}
+</style>
+<style>a{color:#337ab7}a:focus,a:active,a:hover{color:#23527c}.site-branding a{color:#000}.responsive-nav a{color:#ffffff;font-size:14px}.responsive-nav a small{color:#707070;font-size:10px}.responsive-nav a:hover small,.responsive-nav a:active small,.responsive-nav .current-menu-item small,.responsive-nav .current-menu-ancestor small,.responsive-nav .current-menu-parent small,.responsive-nav .current_page_item small,.responsive-nav .current_page_parent small{color:#707070}.responsive-nav .menu>.menu-item>a,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.menu-item>a{background-color:#f4a000;padding:12px 7px}.responsive-nav .menu>.menu-item>a:hover,.responsive-nav .menu>.menu-item>a:active,.responsive-nav .menu>.current-menu-item>a,.responsive-nav .menu>.current-menu-ancestor>a,.responsive-nav .menu>.current-menu-parent>a,.responsive-nav .menu>.current_page_item>a,.responsive-nav .menu>.current_page_parent>a,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.menu-item>a:hover,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.menu-item>a:active,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.current-menu-item>a,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.current-menu-ancestor>a,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.current-menu-parent>a,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.current_page_item>a,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.current_page_parent>a{background-color:#f5f5f5;color:#707070}.responsive-nav .sub-menu a{background-color:#f5f5f5;color:#707070}.responsive-nav .sub-menu a:hover,.responsive-nav .sub-menu a:active,.responsive-nav .sub-menu .current-menu-item a,.responsive-nav .sub-menu .current-menu-ancestor a,.responsive-nav .sub-menu .current-menu-parent a,.responsive-nav .sub-menu .current_page_item a,.responsive-nav .sub-menu .current_page_parent a{background-color:#f5f5f5;color:#707070}.off-canvas-nav{font-size:12px}.responsive-nav,.header--transparency.header--fixed--is_scrolled .responsive-nav{background-color:#f4a000}#responsive-btn{background-color:transparent;border-color:#eeeeee;color:#000}#responsive-btn:hover{background-color:#f5f5f5;border-color:#eee;color:#000}.habakiri-slider__transparent-layer{background-color:rgba( 0,0,0, 0.1 )}.page-header{background-color:#dddddd;color:#fff}.pagination>li>a{color:#337ab7}.pagination>li>span{background-color:#337ab7;border-color:#337ab7}.pagination>li>a:focus,.pagination>li>a:hover,.pagination>li>span:focus,.pagination>li>span:hover{color:#23527c}.header{background-color:#fff}.header--transparency.header--fixed--is_scrolled{background-color:#fff !important}.footer{background-color:#f49000}.footer-widget-area a{color:#777}.footer-widget-area,.footer-widget-area .widget_calendar #wp-calendar caption{color:#555}.footer-widget-area .widget_calendar #wp-calendar,.footer-widget-area .widget_calendar #wp-calendar *{border-color:#555}@media(min-width:992px){.responsive-nav{display:block}.off-canvas-nav,#responsive-btn{display:none !important}.header--2row{padding-bottom:0}.header--2row .header__col,.header--center .header__col{display:block}.header--2row .responsive-nav,.header--center .responsive-nav{margin-right:-1000px;margin-left:-1000px;padding-right:1000px;padding-left:1000px}.header--center .site-branding{text-align:center}}</style><link rel="icon" href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2022/12/favicon.png" sizes="32x32" />
+<link rel="icon" href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2022/12/favicon.png" sizes="192x192" />
+<link rel="apple-touch-icon" href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2022/12/favicon.png" />
+<meta name="msapplication-TileImage" content="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2022/12/favicon.png" />
+<style type="text/css" id="wp-custom-css">
+.cl_rd {
+color: #F00;
+}
+.responsive-nav .sub-menu a {
+background-color: #f5f5f5;
+color: #707070;
+font-weight:bold
+}
+body{
+  word-wrap : break-word;
+  overflow-wrap : break-word;
+}
+
+img {
+    -webkit-backface-visibility: hidden;
+}
+@media print {
+.scroll-back-to-top-wrapper{
+display: none !important;
+}
+}
+
+.spmenu2 {
+             padding:  10px 0 0;
+    }
+@media screen and (max-width: 991px) {
+    .spmenu {
+       /* border-bottom: solid 1px #ffcf74;*/
+        padding:  0 0 10px;
+width: 100%;
+    }
+}</style>
+</head>
+<body data-rsssl=1 class="home page-template page-template-templates page-template-rich-front-page page-template-templatesrich-front-page-php page page-id-22 _masterslider _ms_version_3.10.0">
+<div id="container">
+<header id="header" class="header header--2row ">
+<div class="container">
+<div class="row header__content">
+<div class="col-xs-10 col-md-12 header__col">
+<div class ="row">
+<div class="col-md-6 col-sm-12">
+
+<div class="site-branding">
+<h1 class="site-branding__heading">
+<a href="./index.html" rel="home"><img src="https://keisatsubyoin.or.jp/wordpress/wp-content/uploads/2020/03/logo.png" alt="Tokyo Metropolitan Police Hospital" class="site-branding__logo" /></a></h1>
+<!-- end .site-branding --></div>
+                        </div>
+<div class="col-md-6 col-sm-12 h-btn-flex">
+<div id="site-cr">
+<a href="./index.html" class="h-btn current">Website for Patients</a>
+<a href="https://www.keisatsubyoin.or.jp/m/" class="h-btn">Website for Healthcare Professionals</a>
+</div>
+                        <ul class="topnav2">
+<li class="f-cv-tel"><i class="fas fa-phone-volume"></i>03-5343-5611<span style="font-size:12px"> (Main)</span><!--<span class="h-time">【Reception Hours】8:00~11:30/12:30~16:00</span>--></li>
+</ul>
+                        </div>
+                 </div>
+         <!-- end .header__col --></div>
+<div class="col-xs-2 col-md-12 header__col global-nav-wrapper clearfix">
+
+<nav class="global-nav js-responsive-nav nav--hide" role="navigation">
+<div class="menu-gnavi-container"><ul id="menu-gnavi" class="menu"><li id="menu-item-35" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-35"><a href="./index.html"><div class="m-icon"><i class="fas fa-home"></i>Home</div></a></li>
+<li id="menu-item-157" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-157"><a href="./outpatient.html"><div class="m-icon"><i class="fas fa-stethoscope"></i>Outpatient Visits</div></a>
+<ul class="sub-menu">
+<li id="menu-item-170" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-170"><a href="./outpatient.html">For First-Time Patients</a></li>
+<li id="menu-item-172" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-172"><a href="./outpatient.html">For Returning Patients</a></li>
+<li id="menu-item-12181" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-12181"><a href="./outpatient.html">About Nighttime &amp; Holiday Clinics</a></li>
+<li id="menu-item-171" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-171"><a href="./outpatient.html">For Patients with Referral Letters</a></li>
+<li id="menu-item-10898" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-10898"><a href="./outpatient.html">About Focused Referral Medical Institutions</a></li>
+<li id="menu-item-169" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-169"><a href="./outpatient.html">Community Primary Care Physicians</a></li>
+<li id="menu-item-158" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-158"><a href="./outpatient.html">About Medications</a></li>
+</ul>
+</li>
+<li id="menu-item-32" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-32"><a href="./departments.html"><div class="m-icon"><i class="fas fa-syringe"></i>Departments &amp; Divisions</div></a></li>
+<li id="menu-item-190" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-190"><a href="./inpatient.html"><div class="m-icon"><i class="fas fa-bed"></i>Inpatient Guide</div></a>
+<ul class="sub-menu">
+<li id="menu-item-194" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-194"><a href="./inpatient.html">Admission &amp; Discharge</a></li>
+<li id="menu-item-191" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-191"><a href="./inpatient.html">For Visitors</a></li>
+<li id="menu-item-193" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-193"><a href="./inpatient.html">Life During Hospitalization</a></li>
+<li id="menu-item-196" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-196"><a href="./inpatient.html">About Patient Rooms</a></li>
+<li id="menu-item-192" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-192"><a href="./inpatient.html">Messages to Inpatients</a></li>
+<li id="menu-item-195" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-195"><a href="./inpatient.html">About DPC</a></li>
+</ul>
+</li>
+<li id="menu-item-332" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-332"><a href="./about.html"><div class="m-icon"><i class="fas fa-hospital-alt"></i>About the Hospital</div></a>
+<ul class="sub-menu">
+<li id="menu-item-330" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-330"><a href="./about.html">Message from the Hospital Director</a></li>
+<li id="menu-item-338" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-338"><a href="./about.html">Overview &amp; History</a></li>
+<li id="menu-item-318" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-318"><a href="./about.html">Philosophy &amp; Core Policies</a></li>
+<li id="menu-item-5336" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-5336"><a href="./about.html">Policy on Refusal of Blood Transfusions</a></li>
+<li id="menu-item-317" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-317"><a href="./about.html">Patients' Rights &amp; Responsibilities</a></li>
+<li id="menu-item-7761" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-7761"><a href="./about.html">Request for Comprehensive Consent</a></li>
+<li id="menu-item-319" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-319"><a href="./about.html">Partnership with Patients</a></li>
+<li id="menu-item-329" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-329"><a href="./about.html">Facility Guide</a></li>
+<li id="menu-item-321" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-321"><a href="./about.html">Professional Accreditations</a></li>
+<li id="menu-item-322" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-322"><a href="./about.html">Advanced Medical Equipment</a></li>
+<li id="menu-item-323" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-323"><a href="./about.html">Accredited Hospital Functions</a></li>
+<li id="menu-item-325" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-325"><a href="./about.html">Tokyo Police Hospital by the Numbers</a></li>
+<li id="menu-item-4097" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4097"><a href="https://www.keisatsubyoin.or.jp/privacy/">Privacy Policy</a></li>
+<li id="menu-item-4098" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4098"><a href="https://www.keisatsubyoin.or.jp/nextgeneration/">Next Generation Development Support Measures</a></li>
+<li id="menu-item-4099" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4099"><a href="https://www.keisatsubyoin.or.jp/josei/">Women's Advancement Promotion Plan</a></li>
+<li id="menu-item-4197" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4197"><a href="./about.html">Notices Required by the Minister of Health, Labour and Welfare</a></li>
+</ul>
+</li>
+<li id="menu-item-357" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-357"><a href="./support.html"><div class="m-icon"><i class="fas fa-comment-dots"></i>Consultation &amp; Support</div></a>
+<ul class="sub-menu">
+<li id="menu-item-364" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-364"><a href="./support.html">Information Desk</a></li>
+<li id="menu-item-365" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-365"><a href="./support.html">About Second Opinions</a></li>
+<li id="menu-item-362" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-362"><a href="./support.html">Nutrition Counseling &amp; Guidance</a></li>
+<li id="menu-item-361" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-361"><a href="./support.html">Medical Social Services</a></li>
+<li id="menu-item-359" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-359"><a href="./support.html">Access to Medical Records</a></li>
+<li id="menu-item-358" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-358"><a href="./support.html">Clinical Support Team</a></li>
+<li id="menu-item-360" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-360"><a href="./support.html">Frequently Asked Questions</a></li>
+<li id="menu-item-363" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-363"><a href="./support.html">Patient Safety</a></li>
+<li id="menu-item-1573" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1573"><a href="./support.html">Telephone Use</a></li>
+<li id="menu-item-4209" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4209"><a href="./support.html">Suggestion Box</a></li>
+<li id="menu-item-1577" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-1577"><a href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2023/03/患者さま図書コーナーのご案内.pdf">Patient Library Corner</a></li>
+<li id="menu-item-4100" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4100"><a href="https://www.keisatsubyoin.or.jp/news_090821_dog/">Assistance Dogs for Persons with Disabilities</a></li>
+<li id="menu-item-4101" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4101"><a href="https://www.keisatsubyoin.or.jp/research/">Clinical Trials &amp; Research</a></li>
+</ul>
+</li>
+<li id="menu-item-31" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-31"><a href="./access.html"><div class="m-icon"><i class="fas fa-map-marker-alt"></i>Access</div></a></li>
+</ul></div><!-- end .global-nav --></nav>
+<div id="responsive-btn"></div>
+</div>
+<!-- end .header__col --></div>
+<!-- end .container --></div>
+<!-- end #header --></header>
+<div id="contents">
+  <main class="container" role="main">
+    <h1>Inpatient Guide</h1>
+    <p>Content coming soon.</p>
+  </main>
+<!-- end #contents --></div>
+<footer id="footer" class="footer">
+
+
+<div class="f-menuArea">
+<div class="container">
+<ul class="f-menu">
+<li>
+<div class="spmenu"><i class="fas fa-chevron-right"></i><a href="./outpatient.html">Outpatient Visits</a></div>
+<ul class="f-sub-menu">
+<li><a href="./outpatient.html">For First-Time Patients</a></li>
+<li><a href="./outpatient.html">For Returning Patients</a></li>
+<li><a href="./outpatient.html">Nighttime &amp; Holiday (After-Hours) Clinics</a></li>
+<li><a href="./outpatient.html">For Patients with Referral Letters</a></li>
+<li><a href="./outpatient.html">About Focused Referral Medical Institutions</a></li>
+<li><a href="./outpatient.html">Keep a Community Primary Care Physician</a></li>
+<li><a href="./outpatient.html">About Medications</a></li>
+</ul>
+<div class="spmenu2"><i class="fas fa-chevron-right"></i><a href="./departments.html">Departments &amp; Divisions</a></div>
+</li>
+<li><i class="fas fa-chevron-right"></i><a href="./inpatient.html">Inpatient Guide</a>
+<ul class="f-sub-menu">
+<li><a href="./inpatient.html">About Admission &amp; Discharge</a></li>
+<li><a href="./inpatient.html">For Visitors</a></li>
+<li><a href="./inpatient.html">Life During Hospitalization</a></li>
+<li><a href="./inpatient.html">About Patient Rooms</a></li>
+<li><a href="./inpatient.html">About Messages to Patients</a></li>
+<li><a href="./inpatient.html">About DPC</a></li>
+</ul>
+</li>
+<li><i class="fas fa-chevron-right"></i><a href="./about.html">About the Hospital</a>
+<ul class="f-sub-menu">
+<li><a href="./about.html">Message from the Hospital Director</a></li>
+<li><a href="./about.html">Hospital Overview</a></li>
+<li><a href="./about.html">Philosophy / Core Policies</a></li>
+<li><a href="./about.html">Policy on Refusal of Blood Transfusions</a></li>
+<li><a href="./about.html">Patients' Rights &amp; Responsibilities</a></li>
+<li><a href="./about.html">Request for Comprehensive Consent</a></li>
+<li><a href="./about.html">Partnership with Patients</a></li>
+<!--<li><a href="./about.html">Organization / Committees</a></li>-->
+<li><a href="./about.html">Floor Guide / On-Site Services</a></li>
+<li><a href="./about.html">Professional Accreditations</a></li>
+<li><a href="./about.html">Advanced Medical Equipment</a></li>
+<li><a href="./about.html">Hospital Function Accreditation</a></li>
+<li><a href="./about.html">Tokyo Police Hospital by the Numbers (Clinical Indicators)</a></li>
+<!--<li><a href="./about.html">History</a></li>-->
+<li><a href="https://www.keisatsubyoin.or.jp/privacy/">Privacy Policy</a></li>
+<li><a href="https://www.keisatsubyoin.or.jp/nextgeneration/">Next Generation Development Support Measures</a></li>
+<li><a href="https://www.keisatsubyoin.or.jp/josei/">Women's Advancement Promotion Plan</a></li>
+<li><a href="./about.html">Notices Required by the Minister of Health, Labour and Welfare</a></li>
+<li><a href="https://www.keisatsubyoin.or.jp/sitemap/">Site Map</a></li>
+</ul>
+</li>
+<li><div class="spmenu"><i class="fas fa-chevron-right"></i><a href="./support.html">Consultation &amp; Support</a></div>
+<ul class="f-sub-menu">
+<li><a href="./support.html">Information Desk</a></li>
+<li><a href="./support.html">Second Opinions</a></li>
+<li><a href="./support.html">Meals &amp; Nutrition Guidance</a></li>
+<li><a href="./support.html">Medical Social Services</a></li>
+<li><a href="./support.html">Access to Medical Records</a></li>
+<li><a href="./support.html">Clinical Support</a></li>
+<li><a href="./support.html">Frequently Asked Questions</a></li>
+<li><a href="./support.html">Patient Safety &amp; Infection Control</a></li>
+<li><a href="./support.html">Telephone Use</a></li>
+<li><a href="./support.html">Suggestion Box</a></li>
+<li><a href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2023/03/患者さま図書コーナーのご案内.pdf">Patient Library Corner</a></li>
+<!--<li><a href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2020/02/vol.11_Kanjasama-Tosyo.pdf#page=1&zoom=200">Patient Library Corner</a></li>-->
+<li><a href="https://www.keisatsubyoin.or.jp/news_090821_dog/">Assistance Dogs for Persons with Disabilities</a></li>
+<li><a href="https://www.keisatsubyoin.or.jp/research/">Clinical Trials &amp; Research</a></li>
+</ul>
+<div class="spmenu2"><i class="fas fa-chevron-right"></i><a href="./access.html">Access</a></div>
+</li>
+</ul>
+</div>
+</div>
+<div class="copyright">
+<div class="container">
+&copy; Tokyo Metropolitan Police Hospital 4-22-1 Nakano, Nakano-ku, Tokyo
+<!-- end .container --></div>
+<!-- end .copyright --></div>
+<!-- end #footer --></footer>
+<!-- end #container --></div>
+<div class="scroll-back-to-top-wrapper">
+<span class="scroll-back-to-top-inner">
+<i class="fa fa-2x fa-arrow-circle-up"></i>
+</span>
+</div><script>
+jQuery( function( $ ) {
+$( '.js-responsive-nav' ).responsive_nav( {
+direction: 'right'
+} );
+} );
+</script>
+<link rel='stylesheet' id='metaslider-flex-slider-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/ml-slider/assets/sliders/flexslider/flexslider.css?ver=3.93.0' type='text/css' media='all' property='stylesheet' />
+<link rel='stylesheet' id='metaslider-public-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/ml-slider/assets/metaslider/public.css?ver=3.93.0' type='text/css' media='all' property='stylesheet' />
+<style id='metaslider-public-inline-css' type='text/css'>
+@media only screen and (max-width: 767px) {body:after { display: none; content: "smartphone"; } .hide-arrows-smartphone .flex-direction-nav, .hide-navigation-smartphone .flex-control-paging, .hide-navigation-smartphone .flex-control-nav, .hide-navigation-smartphone .filmstrip{ display: none!important; }}@media only screen and (min-width : 768px) and (max-width: 1023px) {body:after { display: none; content: "tablet"; } .hide-arrows-tablet .flex-direction-nav, .hide-navigation-tablet .flex-control-paging, .hide-navigation-tablet .flex-control-nav, .hide-navigation-tablet .filmstrip{ display: none!important; }}@media only screen and (min-width : 1024px) and (max-width: 1439px) {body:after { display: none; content: "laptop"; } .hide-arrows-laptop .flex-direction-nav, .hide-navigation-laptop .flex-control-paging, .hide-navigation-laptop .flex-control-nav, .hide-navigation-laptop .filmstrip{ display: none!important; }}@media only screen and (min-width : 1440px) {body:after { display: none; content: "desktop"; } .hide-arrows-desktop .flex-direction-nav, .hide-navigation-desktop .flex-control-paging, .hide-navigation-desktop .flex-control-nav, .hide-navigation-desktop .filmstrip{ display: none!important; }}
+@media only screen and (max-width: 767px) {body:after { display: none; content: "smartphone"; } .hide-arrows-smartphone .flex-direction-nav, .hide-navigation-smartphone .flex-control-paging, .hide-navigation-smartphone .flex-control-nav, .hide-navigation-smartphone .filmstrip{ display: none!important; }}@media only screen and (min-width : 768px) and (max-width: 1023px) {body:after { display: none; content: "tablet"; } .hide-arrows-tablet .flex-direction-nav, .hide-navigation-tablet .flex-control-paging, .hide-navigation-tablet .flex-control-nav, .hide-navigation-tablet .filmstrip{ display: none!important; }}@media only screen and (min-width : 1024px) and (max-width: 1439px) {body:after { display: none; content: "laptop"; } .hide-arrows-laptop .flex-direction-nav, .hide-navigation-laptop .flex-control-paging, .hide-navigation-laptop .flex-control-nav, .hide-navigation-laptop .filmstrip{ display: none!important; }}@media only screen and (min-width : 1440px) {body:after { display: none; content: "desktop"; } .hide-arrows-desktop .flex-direction-nav, .hide-navigation-desktop .flex-control-paging, .hide-navigation-desktop .flex-control-nav, .hide-navigation-desktop .filmstrip{ display: none!important; }}
+</style>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/embed-any-document/js/pdfobject.min.js?ver=2.7.4' id='awsm-ead-pdf-object-js'></script>
+<script type='text/javascript' id='awsm-ead-public-js-extra'>
+/* <![CDATA[ */
+var eadPublic = [];
+/* ]]> */
+</script>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/embed-any-document/js/embed-public.min.js?ver=2.7.4' id='awsm-ead-public-js'></script>
+<script type='text/javascript' id='scroll-back-to-top-js-extra'>
+/* <![CDATA[ */
+var scrollBackToTop = {"scrollDuration":"500","fadeDuration":"0.5"};
+/* ]]> */
+</script>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/scroll-back-to-top/assets/js/scroll-back-to-top.js' id='scroll-back-to-top-js'></script>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri/js/app.min.js?ver=6.2.8' id='habakiri-js'></script>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/ml-slider/assets/sliders/flexslider/jquery.flexslider.min.js?ver=3.93.0' id='metaslider-flex-slider-js'></script>
+<script type='text/javascript' id='metaslider-flex-slider-js-after'>
+var metaslider_38 = function($) {$('#metaslider_38').addClass('flexslider');
+            $('#metaslider_38').flexslider({ 
+                slideshowSpeed:6000,
+                animation:"fade",
+                controlNav:true,
+                directionNav:true,
+                pauseOnHover:true,
+                direction:"horizontal",
+                reverse:false,
+                keyboard:false,
+                touch:true,
+                animationSpeed:2000,
+                prevText:"Previous",
+                nextText:"Next",
+                smoothHeight:false,
+                fadeFirstSlide:false,
+                slideshow:true,
+                pausePlay:false
+            });
+            $(document).trigger('metaslider/initialized', '#metaslider_38');
+        };
+        var timer_metaslider_38 = function() {
+            var slider = !window.jQuery ? window.setTimeout(timer_metaslider_38, 100) : !jQuery.isReady ? window.setTimeout(timer_metaslider_38, 1) : metaslider_38(window.jQuery);
+        };
+        timer_metaslider_38();
+var metaslider_40 = function($) {$('#metaslider_40').addClass('flexslider');
+            $('#metaslider_40').flexslider({ 
+                slideshowSpeed:6000,
+                animation:"fade",
+                controlNav:false,
+                directionNav:false,
+                pauseOnHover:true,
+                direction:"horizontal",
+                reverse:false,
+                keyboard:false,
+                touch:true,
+                animationSpeed:2000,
+                prevText:"Previous",
+                nextText:"Next",
+                smoothHeight:false,
+                fadeFirstSlide:false,
+                slideshow:true,
+                pausePlay:false
+            });
+            $(document).trigger('metaslider/initialized', '#metaslider_40');
+        };
+        var timer_metaslider_40 = function() {
+            var slider = !window.jQuery ? window.setTimeout(timer_metaslider_40, 100) : !jQuery.isReady ? window.setTimeout(timer_metaslider_40, 1) : metaslider_40(window.jQuery);
+        };
+        timer_metaslider_40();
+</script>
+<script type='text/javascript' id='metaslider-script-js-extra'>
+/* <![CDATA[ */
+var wpData = {"baseUrl":"https:\/\/www.keisatsubyoin.or.jp"};
+var wpData = {"baseUrl":"https:\/\/www.keisatsubyoin.or.jp"};
+/* ]]> */
+</script>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/ml-slider/assets/metaslider/script.min.js?ver=3.93.0' id='metaslider-script-js'></script>
+<div id="footerFloatingMenu">
+<ul>
+<li class="ft-tel"><a href="tel:03-5343-5611"><i class="fas fa-phone-volume fa-lg"></i>Call Us</a></li>
+<!--<li class="ft-web"><a href="#" target="_blank"><i class="far fa-calendar-alt"></i>Online Booking</a></li>-->
+<li class="ft-access"><a href="/access/"><i class="fas fa-map-marker-alt"></i>Access</a></li>
+</ul>
+</div>
+<script type="text/javascript" src="https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri-child-1/js-child/jquery.rwdImageMaps.min.js"></script>
+<script>
+//Accordion
+jQuery(function(){
+ 
+    //.accordion1 paragraphs toggle their sibling ul elements when clicked
+jQuery('.accordion1 p').click(function(){
+ 
+jQuery(this).next('ul').slideToggle();
+ 
+});
+});
+//End accordion
+
+//Image map responsiveness
+jQuery(document).ready(function(e) {
+jQuery('img[usemap]').rwdImageMaps()
+});
+//End image map responsiveness
+jQuery(window).on('load', function() {
+var url = jQuery(location).attr('href');
+if(url.indexOf("#") != -1){
+var anchor = url.split("#");
+var target = jQuery('#' + anchor[anchor.length - 1]);
+if(target.length){
+var pos = Math.floor(target.offset().top) - 180;
+jQuery("html, body").animate({scrollTop:pos}, 300);
+}
+}
+});
+
+</script>
+<script>
+jQuery(function() {
+jQuery('.nav-tab > li').on('click',function(){
+jQuery('.nav-tab > li').removeClass('active')
+jQuery(this).addClass('active')
+var index = jQuery('.nav-tab > li').index(this);
+jQuery('#categoryTab > ul').removeClass('show'); 
+jQuery('#categoryTab > ul').eq(index).addClass('show'); 
+});
+});
+</script>
+
+<script>
+(function() {
+  var map = [
+    {prefix: "/", to: "./index.html"},
+    {prefix: "/profile/", to: "./about.html"},
+    {prefix: "/shinryoka/", to: "./departments.html"},
+    {prefix: "/gairai/", to: "./outpatient.html"},
+    {prefix: "/nyuin/", to: "./inpatient.html"},
+    {prefix: "/support/", to: "./support.html"},
+    {prefix: "/access/", to: "./access.html"}
+  ];
+  function remap(u) {
+    var p = u.pathname || "/";
+    var m = map.slice().sort(function(a, b) {
+      return b.prefix.length - a.prefix.length;
+    }).find(function(x) {
+      return p.indexOf(x.prefix) === 0;
+    });
+    return m ? m.to : null;
+  }
+  document.addEventListener('DOMContentLoaded', function() {
+    document.querySelectorAll('a[href]').forEach(function(a) {
+      try {
+        var u = new URL(a.getAttribute('href'), location.href);
+        if (/(^|\.)keisatsubyoin\.or\.jp$/i.test(u.hostname)) {
+          var to = remap(u);
+          if (to) {
+            a.setAttribute('href', to);
+          }
+        }
+      } catch (e) {}
+    });
+  });
+})();
+</script>
+
+</body>
+</html>

--- a/outpatient.html
+++ b/outpatient.html
@@ -1,0 +1,659 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en" prefix="og: https://ogp.me/ns#">
+<head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# article: http://ogp.me/ns/article#">
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<link rel="shortcut icon" href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2022/12/favicon.png" />
+<link rel="pingback" href="https://www.keisatsubyoin.or.jp/wordpress/xmlrpc.php" />
+<link href="https://use.fontawesome.com/releases/v5.0.10/css/all.css" rel="stylesheet">
+<link rel="stylesheet" href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri-child-1/css/pageheader-style.css" />
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-VTBF3Q2K4B"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-VTBF3Q2K4B');
+</script>
+<!--[if lt IE 9]>
+<script src="https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri/js/html5shiv.min.js"></script>
+<![endif]-->
+<title>Outpatient Services | Tokyo Metropolitan Police Hospital</title>
+
+<!-- All in One SEO 4.7.6 - aioseo.com -->
+<meta name="description" content="Content coming soon." />
+<meta name="robots" content="max-image-preview:large" />
+<meta name="msvalidate.01" content="6025B7F66D63703BEED4E4073634721A" />
+<link rel="canonical" href="./outpatient.html" />
+<meta name="generator" content="All in One SEO (AIOSEO) 4.7.6" />
+
+<meta name="google-site-verification" content="97tlZIAoAnOmR7w1s9-GNtXfEEnBRDb7DyN4QJ3Lv3s" />
+<meta property="og:locale" content="en_US" />
+<meta property="og:site_name" content="Tokyo Metropolitan Police Hospital | Medical Care That Protects Those You Love | Tokyo Metropolitan Police Hospital in Nakano Ward Welcomes All Community Members" />
+<meta property="og:type" content="website" />
+<meta property="og:title" content="Outpatient Services | Tokyo Metropolitan Police Hospital" />
+<meta property="og:description" content="Medical care that protects those you love | Tokyo Metropolitan Police Hospital in Nakano Ward welcomes anyone in the community." />
+<meta property="og:url" content="./outpatient.html" />
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content="Outpatient Services | Tokyo Metropolitan Police Hospital" />
+<meta name="twitter:description" content="Content coming soon." />
+<script type="application/ld+json" class="aioseo-schema">
+{"@context":"https:\/\/schema.org","@graph":[{"@type":"BreadcrumbList","@id":"https:\/\/www.keisatsubyoin.or.jp\/#breadcrumblist","itemListElement":[{"@type":"ListItem","@id":"https:\/\/www.keisatsubyoin.or.jp\/#listItem","position":1,"name":"Home"}]},{"@type":"Organization","@id":"https:\/\/www.keisatsubyoin.or.jp\/#organization","name":"Tokyo Metropolitan Police Hospital","description":"Medical care that protects those you love | Tokyo Metropolitan Police Hospital in Nakano Ward welcomes anyone in the community.","url":"https:\/\/www.keisatsubyoin.or.jp\/"},{"@type":"WebPage","@id":"https:\/\/www.keisatsubyoin.or.jp\/#webpage","url":"https:\/\/www.keisatsubyoin.or.jp\/","name":"Tokyo Metropolitan Police Hospital | Medical Care That Protects Those You Love | Tokyo Metropolitan Police Hospital in Nakano Ward Welcomes All Community Members","description":"Medical care that protects those you love | Tokyo Metropolitan Police Hospital in Nakano Ward welcomes anyone in the community.","inLanguage":"en","isPartOf":{"@id":"https:\/\/www.keisatsubyoin.or.jp\/#website"},"breadcrumb":{"@id":"https:\/\/www.keisatsubyoin.or.jp\/#breadcrumblist"},"datePublished":"2019-12-03T08:15:37+09:00","dateModified":"2025-05-01T10:08:09+09:00"},{"@type":"WebSite","@id":"https:\/\/www.keisatsubyoin.or.jp\/#website","url":"https:\/\/www.keisatsubyoin.or.jp\/","name":"Tokyo Metropolitan Police Hospital","description":"Medical care that protects those you love | Tokyo Metropolitan Police Hospital in Nakano Ward welcomes anyone in the community.","inLanguage":"en","publisher":{"@id":"https:\/\/www.keisatsubyoin.or.jp\/#organization"},"potentialAction":{"@type":"SearchAction","target":{"@type":"EntryPoint","urlTemplate":"https:\/\/www.keisatsubyoin.or.jp\/?s={search_term_string}"},"query-input":"required name=search_term_string"}}]}
+</script>
+<!-- All in One SEO -->
+
+<link rel='dns-prefetch' href='//netdna.bootstrapcdn.com' />
+<link rel="alternate" type="application/rss+xml" title="Tokyo Metropolitan Police Hospital &raquo; Feed" href="https://www.keisatsubyoin.or.jp/feed/" />
+<script type="text/javascript">
+window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/14.0.0\/72x72\/","ext":".png","svgUrl":"https:\/\/s.w.org\/images\/core\/emoji\/14.0.0\/svg\/","svgExt":".svg","source":{"concatemoji":"https:\/\/www.keisatsubyoin.or.jp\/wordpress\/wp-includes\/js\/wp-emoji-release.min.js?ver=6.2.8"}};
+/*! This file is auto-generated */
+!function(e,a,t){var n,r,o,i=a.createElement("canvas"),p=i.getContext&&i.getContext("2d");function s(e,t){p.clearRect(0,0,i.width,i.height),p.fillText(e,0,0);e=i.toDataURL();return p.clearRect(0,0,i.width,i.height),p.fillText(t,0,0),e===i.toDataURL()}function c(e){var t=a.createElement("script");t.src=e,t.defer=t.type="text/javascript",a.getElementsByTagName("head")[0].appendChild(t)}for(o=Array("flag","emoji"),t.supports={everything:!0,everythingExceptFlag:!0},r=0;r<o.length;r++)t.supports[o[r]]=function(e){if(p&&p.fillText)switch(p.textBaseline="top",p.font="600 32px Arial",e){case"flag":return s("\ud83c\udff3\ufe0f\u200d\u26a7\ufe0f","\ud83c\udff3\ufe0f\u200b\u26a7\ufe0f")?!1:!s("\ud83c\uddfa\ud83c\uddf3","\ud83c\uddfa\u200b\ud83c\uddf3")&&!s("\ud83c\udff4\udb40\udc67\udb40\udc62\udb40\udc65\udb40\udc6e\udb40\udc67\udb40\udc7f","\ud83c\udff4\u200b\udb40\udc67\u200b\udb40\udc62\u200b\udb40\udc65\u200b\udb40\udc6e\u200b\udb40\udc67\u200b\udb40\udc7f");case"emoji":return!s("\ud83e\udef1\ud83c\udffb\u200d\ud83e\udef2\ud83c\udfff","\ud83e\udef1\ud83c\udffb\u200b\ud83e\udef2\ud83c\udfff")}return!1}(o[r]),t.supports.everything=t.supports.everything&&t.supports[o[r]],"flag"!==o[r]&&(t.supports.everythingExceptFlag=t.supports.everythingExceptFlag&&t.supports[o[r]]);t.supports_everythingExceptFlag=t.supports.everythingExceptFlag&&!t.supports.flag,t.DOMReady=!1,t.readyCallback=function(){t.DOMReady=!0},t.supports.everything||(n=function(){t.readyCallback()},a.addEventListener?(a.addEventListener("DOMContentLoaded",n,!1),e.addEventListener("load",n,!1)):(e.attachEvent("onload",n),a.attachEvent("onreadystatechange",function(){"complete"===a.readyState&&t.readyCallback()})),(e=t.source||{}).concatemoji?c(e.concatemoji):e.wpemoji&&e.twemoji&&(c(e.twemoji),c(e.wpemoji)))}(window,document,window._wpemojiSettings);
+</script>
+<style type="text/css">
+img.wp-smiley,
+img.emoji {
+display: inline !important;
+border: none !important;
+box-shadow: none !important;
+height: 1em !important;
+width: 1em !important;
+margin: 0 0.07em !important;
+vertical-align: -0.1em !important;
+background: none !important;
+padding: 0 !important;
+}
+</style>
+<link rel='stylesheet' id='wp-block-library-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-includes/css/dist/block-library/style.min.css?ver=6.2.8' type='text/css' media='all' />
+<style id='pdfemb-pdf-embedder-viewer-style-inline-css' type='text/css'>
+.wp-block-pdfemb-pdf-embedder-viewer{max-width:none}
+
+</style>
+<link rel='stylesheet' id='awsm-ead-public-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/embed-any-document/css/embed-public.min.css?ver=2.7.4' type='text/css' media='all' />
+<link rel='stylesheet' id='classic-theme-styles-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-includes/css/classic-themes.min.css?ver=6.2.8' type='text/css' media='all' />
+<style id='global-styles-inline-css' type='text/css'>
+body{
+--wp--preset--color--black: #000000;
+--wp--preset--color--cyan-bluish-gray: #abb8c3;
+--wp--preset--color--white: #ffffff;
+--wp--preset--color--pale-pink: #f78da7;
+--wp--preset--color--vivid-red: #cf2e2e;
+--wp--preset--color--luminous-vivid-orange: #ff6900;
+--wp--preset--color--luminous-vivid-amber: #fcb900;
+--wp--preset--color--light-green-cyan: #7bdcb5;
+--wp--preset--color--vivid-green-cyan: #00d084;
+--wp--preset--color--pale-cyan-blue: #8ed1fc;
+--wp--preset--color--vivid-cyan-blue: #0693e3;
+--wp--preset--color--vivid-purple: #9b51e0;
+--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%);
+--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan: linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%);
+--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange: linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%);
+--wp--preset--gradient--luminous-vivid-orange-to-vivid-red: linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%);
+--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray: linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%);
+--wp--preset--gradient--cool-to-warm-spectrum: linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186) 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%);
+--wp--preset--gradient--blush-light-purple: linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%);
+--wp--preset--gradient--blush-bordeaux: linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%);
+--wp--preset--gradient--luminous-dusk: linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%);
+--wp--preset--gradient--pale-ocean: linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181) 100%);
+--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128) 0%,rgb(113,206,126) 100%);
+--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%);
+--wp--preset--duotone--dark-grayscale: url('#wp-duotone-dark-grayscale');
+--wp--preset--duotone--grayscale: url('#wp-duotone-grayscale');
+--wp--preset--duotone--purple-yellow: url('#wp-duotone-purple-yellow');
+--wp--preset--duotone--blue-red: url('#wp-duotone-blue-red');
+--wp--preset--duotone--midnight: url('#wp-duotone-midnight');
+--wp--preset--duotone--magenta-yellow: url('#wp-duotone-magenta-yellow');
+--wp--preset--duotone--purple-green: url('#wp-duotone-purple-green');
+--wp--preset--duotone--blue-orange: url('#wp-duotone-blue-orange');
+--wp--preset--font-size--small: 13px;
+--wp--preset--font-size--medium: 20px;
+--wp--preset--font-size--large: 36px;
+--wp--preset--font-size--x-large: 42px;
+--wp--preset--spacing--20: 0.44rem;
+--wp--preset--spacing--30: 0.67rem;
+--wp--preset--spacing--40: 1rem;
+--wp--preset--spacing--50: 1.5rem;
+--wp--preset--spacing--60: 2.25rem;
+--wp--preset--spacing--70: 3.38rem;
+--wp--preset--spacing--80: 5.06rem;
+--wp--preset--shadow--natural: 6px 6px 9px rgba(0, 0, 0, 0.2);
+--wp--preset--shadow--deep: 12px 12px 50px rgba(0, 0, 0, 0.4);
+--wp--preset--shadow--sharp: 6px 6px 0px rgba(0, 0, 0, 0.2);
+--wp--preset--shadow--outlined: 6px 6px 0px -3px rgba(255, 255, 255, 1), 6px 6px rgba(0, 0, 0, 1);
+--wp--preset--shadow--crisp: 6px 6px 0px rgba(0, 0, 0, 1);
+}
+:where(.is-layout-flex){gap: 0.5em;}
+body .is-layout-flow > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}
+body .is-layout-flow > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}
+body .is-layout-flow > .aligncenter{margin-left: auto !important;margin-right: auto !important;}
+body .is-layout-constrained > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}
+body .is-layout-constrained > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}
+body .is-layout-constrained > .aligncenter{margin-left: auto !important;margin-right: auto !important;}
+body .is-layout-constrained > :where(:not(.alignleft):not(.alignright):not(.alignfull)){max-width: var(--wp--style--global--content-size);margin-left: auto !important;margin-right: auto !important;}
+body .is-layout-constrained > .alignwide{max-width: var(--wp--style--global--wide-size);}
+body .is-layout-flex{display: flex;}
+body .is-layout-flex{flex-wrap: wrap;align-items: center;}
+body .is-layout-flex > *{margin: 0;}
+:where(.wp-block-columns.is-layout-flex){gap: 2em;}
+.has-black-color{color: var(--wp--preset--color--black) !important;}
+.has-cyan-bluish-gray-color{color: var(--wp--preset--color--cyan-bluish-gray) !important;}
+.has-white-color{color: var(--wp--preset--color--white) !important;}
+.has-pale-pink-color{color: var(--wp--preset--color--pale-pink) !important;}
+.has-vivid-red-color{color: var(--wp--preset--color--vivid-red) !important;}
+.has-luminous-vivid-orange-color{color: var(--wp--preset--color--luminous-vivid-orange) !important;}
+.has-luminous-vivid-amber-color{color: var(--wp--preset--color--luminous-vivid-amber) !important;}
+.has-light-green-cyan-color{color: var(--wp--preset--color--light-green-cyan) !important;}
+.has-vivid-green-cyan-color{color: var(--wp--preset--color--vivid-green-cyan) !important;}
+.has-pale-cyan-blue-color{color: var(--wp--preset--color--pale-cyan-blue) !important;}
+.has-vivid-cyan-blue-color{color: var(--wp--preset--color--vivid-cyan-blue) !important;}
+.has-vivid-purple-color{color: var(--wp--preset--color--vivid-purple) !important;}
+.has-black-background-color{background-color: var(--wp--preset--color--black) !important;}
+.has-cyan-bluish-gray-background-color{background-color: var(--wp--preset--color--cyan-bluish-gray) !important;}
+.has-white-background-color{background-color: var(--wp--preset--color--white) !important;}
+.has-pale-pink-background-color{background-color: var(--wp--preset--color--pale-pink) !important;}
+.has-vivid-red-background-color{background-color: var(--wp--preset--color--vivid-red) !important;}
+.has-luminous-vivid-orange-background-color{background-color: var(--wp--preset--color--luminous-vivid-orange) !important;}
+.has-luminous-vivid-amber-background-color{background-color: var(--wp--preset--color--luminous-vivid-amber) !important;}
+.has-light-green-cyan-background-color{background-color: var(--wp--preset--color--light-green-cyan) !important;}
+.has-vivid-green-cyan-background-color{background-color: var(--wp--preset--color--vivid-green-cyan) !important;}
+.has-pale-cyan-blue-background-color{background-color: var(--wp--preset--color--pale-cyan-blue) !important;}
+.has-vivid-cyan-blue-background-color{background-color: var(--wp--preset--color--vivid-cyan-blue) !important;}
+.has-vivid-purple-background-color{background-color: var(--wp--preset--color--vivid-purple) !important;}
+.has-black-border-color{border-color: var(--wp--preset--color--black) !important;}
+.has-cyan-bluish-gray-border-color{border-color: var(--wp--preset--color--cyan-bluish-gray) !important;}
+.has-white-border-color{border-color: var(--wp--preset--color--white) !important;}
+.has-pale-pink-border-color{border-color: var(--wp--preset--color--pale-pink) !important;}
+.has-vivid-red-border-color{border-color: var(--wp--preset--color--vivid-red) !important;}
+.has-luminous-vivid-orange-border-color{border-color: var(--wp--preset--color--luminous-vivid-orange) !important;}
+.has-luminous-vivid-amber-border-color{border-color: var(--wp--preset--color--luminous-vivid-amber) !important;}
+.has-light-green-cyan-border-color{border-color: var(--wp--preset--color--light-green-cyan) !important;}
+.has-vivid-green-cyan-border-color{border-color: var(--wp--preset--color--vivid-green-cyan) !important;}
+.has-pale-cyan-blue-border-color{border-color: var(--wp--preset--color--pale-cyan-blue) !important;}
+.has-vivid-cyan-blue-border-color{border-color: var(--wp--preset--color--vivid-cyan-blue) !important;}
+.has-vivid-purple-border-color{border-color: var(--wp--preset--color--vivid-purple) !important;}
+.has-vivid-cyan-blue-to-vivid-purple-gradient-background{background: var(--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple) !important;}
+.has-light-green-cyan-to-vivid-green-cyan-gradient-background{background: var(--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan) !important;}
+.has-luminous-vivid-amber-to-luminous-vivid-orange-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange) !important;}
+.has-luminous-vivid-orange-to-vivid-red-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-orange-to-vivid-red) !important;}
+.has-very-light-gray-to-cyan-bluish-gray-gradient-background{background: var(--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray) !important;}
+.has-cool-to-warm-spectrum-gradient-background{background: var(--wp--preset--gradient--cool-to-warm-spectrum) !important;}
+.has-blush-light-purple-gradient-background{background: var(--wp--preset--gradient--blush-light-purple) !important;}
+.has-blush-bordeaux-gradient-background{background: var(--wp--preset--gradient--blush-bordeaux) !important;}
+.has-luminous-dusk-gradient-background{background: var(--wp--preset--gradient--luminous-dusk) !important;}
+.has-pale-ocean-gradient-background{background: var(--wp--preset--gradient--pale-ocean) !important;}
+.has-electric-grass-gradient-background{background: var(--wp--preset--gradient--electric-grass) !important;}
+.has-midnight-gradient-background{background: var(--wp--preset--gradient--midnight) !important;}
+.has-small-font-size{font-size: var(--wp--preset--font-size--small) !important;}
+.has-medium-font-size{font-size: var(--wp--preset--font-size--medium) !important;}
+.has-large-font-size{font-size: var(--wp--preset--font-size--large) !important;}
+.has-x-large-font-size{font-size: var(--wp--preset--font-size--x-large) !important;}
+.wp-block-navigation a:where(:not(.wp-element-button)){color: inherit;}
+:where(.wp-block-columns.is-layout-flex){gap: 2em;}
+.wp-block-pullquote{font-size: 1.5em;line-height: 1.6;}
+</style>
+<link rel='stylesheet' id='font-awesome-css' href='//netdna.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.css' type='text/css' media='screen' />
+<link rel='stylesheet' id='habakiri-assets-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri/css/assets.min.css?ver=6.2.8' type='text/css' media='all' />
+<link rel='stylesheet' id='habakiri-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri/style.min.css?ver=20250926050751' type='text/css' media='all' />
+<link rel='stylesheet' id='habakiri-child-1-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri-child-1/style.css?ver=20250926050751' type='text/css' media='all' />
+<link rel='stylesheet' id='msl-main-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/master-slider/public/assets/css/masterslider.main.css?ver=3.10.0' type='text/css' media='all' />
+<link rel='stylesheet' id='msl-custom-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/master-slider/custom.css?ver=4.5' type='text/css' media='all' />
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-includes/js/jquery/jquery.min.js?ver=3.6.4' id='jquery-core-js'></script>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-includes/js/jquery/jquery-migrate.min.js?ver=3.4.0' id='jquery-migrate-js'></script>
+<link rel="https://api.w.org/" href="https://www.keisatsubyoin.or.jp/wp-json/" /><link rel="alternate" type="application/json" href="https://www.keisatsubyoin.or.jp/wp-json/wp/v2/pages/22" /><link rel="EditURI" type="application/rsd+xml" title="RSD" href="https://www.keisatsubyoin.or.jp/wordpress/xmlrpc.php?rsd" />
+<link rel="wlwmanifest" type="application/wlwmanifest+xml" href="https://www.keisatsubyoin.or.jp/wordpress/wp-includes/wlwmanifest.xml" />
+<meta name="generator" content="WordPress 6.2.8" />
+<link rel='shortlink' href='https://www.keisatsubyoin.or.jp/' />
+<link rel="alternate" type="application/json+oembed" href="https://www.keisatsubyoin.or.jp/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.keisatsubyoin.or.jp%2F" />
+<link rel="alternate" type="text/xml+oembed" href="https://www.keisatsubyoin.or.jp/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.keisatsubyoin.or.jp%2F&#038;format=xml" />
+<script>var ms_grabbing_curosr = 'https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/master-slider/public/assets/css/common/grabbing.cur', ms_grab_curosr = 'https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/master-slider/public/assets/css/common/grab.cur';</script>
+<meta name="generator" content="MasterSlider 3.10.0 - Responsive Touch Image Slider | avt.li/msf" />
+
+<style>
+.scroll-back-to-top-wrapper {
+    position: fixed;
+opacity: 0;
+visibility: hidden;
+overflow: hidden;
+text-align: center;
+z-index: 99999999;
+    background-color: #777777;
+color: #eeeeee;
+width: 50px;
+height: 48px;
+line-height: 48px;
+right: 30px;
+bottom: 60px;
+padding-top: 2px;
+border-top-left-radius: 10px;
+border-top-right-radius: 10px;
+border-bottom-right-radius: 10px;
+border-bottom-left-radius: 10px;
+-webkit-transition: all 0.5s ease-in-out;
+-moz-transition: all 0.5s ease-in-out;
+-ms-transition: all 0.5s ease-in-out;
+-o-transition: all 0.5s ease-in-out;
+transition: all 0.5s ease-in-out;
+}
+.scroll-back-to-top-wrapper:hover {
+background-color: #888888;
+  color: #eeeeee;
+}
+.scroll-back-to-top-wrapper.show {
+    visibility:visible;
+    cursor:pointer;
+opacity: 1.0;
+}
+.scroll-back-to-top-wrapper i.fa {
+line-height: inherit;
+}
+.scroll-back-to-top-wrapper .fa-lg {
+vertical-align: 0;
+}
+</style><style>
+/* Safari 6.1+ (10.0 is the latest version of Safari at this time) */
+@media (max-width: 991px) and (min-color-index: 0) and (-webkit-min-device-pixel-ratio: 0) { @media () {
+display: block !important;
+.header__col {
+width: 100%;
+}
+}}
+</style>
+<style>a{color:#337ab7}a:focus,a:active,a:hover{color:#23527c}.site-branding a{color:#000}.responsive-nav a{color:#ffffff;font-size:14px}.responsive-nav a small{color:#707070;font-size:10px}.responsive-nav a:hover small,.responsive-nav a:active small,.responsive-nav .current-menu-item small,.responsive-nav .current-menu-ancestor small,.responsive-nav .current-menu-parent small,.responsive-nav .current_page_item small,.responsive-nav .current_page_parent small{color:#707070}.responsive-nav .menu>.menu-item>a,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.menu-item>a{background-color:#f4a000;padding:12px 7px}.responsive-nav .menu>.menu-item>a:hover,.responsive-nav .menu>.menu-item>a:active,.responsive-nav .menu>.current-menu-item>a,.responsive-nav .menu>.current-menu-ancestor>a,.responsive-nav .menu>.current-menu-parent>a,.responsive-nav .menu>.current_page_item>a,.responsive-nav .menu>.current_page_parent>a,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.menu-item>a:hover,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.menu-item>a:active,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.current-menu-item>a,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.current-menu-ancestor>a,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.current-menu-parent>a,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.current_page_item>a,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.current_page_parent>a{background-color:#f5f5f5;color:#707070}.responsive-nav .sub-menu a{background-color:#f5f5f5;color:#707070}.responsive-nav .sub-menu a:hover,.responsive-nav .sub-menu a:active,.responsive-nav .sub-menu .current-menu-item a,.responsive-nav .sub-menu .current-menu-ancestor a,.responsive-nav .sub-menu .current-menu-parent a,.responsive-nav .sub-menu .current_page_item a,.responsive-nav .sub-menu .current_page_parent a{background-color:#f5f5f5;color:#707070}.off-canvas-nav{font-size:12px}.responsive-nav,.header--transparency.header--fixed--is_scrolled .responsive-nav{background-color:#f4a000}#responsive-btn{background-color:transparent;border-color:#eeeeee;color:#000}#responsive-btn:hover{background-color:#f5f5f5;border-color:#eee;color:#000}.habakiri-slider__transparent-layer{background-color:rgba( 0,0,0, 0.1 )}.page-header{background-color:#dddddd;color:#fff}.pagination>li>a{color:#337ab7}.pagination>li>span{background-color:#337ab7;border-color:#337ab7}.pagination>li>a:focus,.pagination>li>a:hover,.pagination>li>span:focus,.pagination>li>span:hover{color:#23527c}.header{background-color:#fff}.header--transparency.header--fixed--is_scrolled{background-color:#fff !important}.footer{background-color:#f49000}.footer-widget-area a{color:#777}.footer-widget-area,.footer-widget-area .widget_calendar #wp-calendar caption{color:#555}.footer-widget-area .widget_calendar #wp-calendar,.footer-widget-area .widget_calendar #wp-calendar *{border-color:#555}@media(min-width:992px){.responsive-nav{display:block}.off-canvas-nav,#responsive-btn{display:none !important}.header--2row{padding-bottom:0}.header--2row .header__col,.header--center .header__col{display:block}.header--2row .responsive-nav,.header--center .responsive-nav{margin-right:-1000px;margin-left:-1000px;padding-right:1000px;padding-left:1000px}.header--center .site-branding{text-align:center}}</style><link rel="icon" href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2022/12/favicon.png" sizes="32x32" />
+<link rel="icon" href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2022/12/favicon.png" sizes="192x192" />
+<link rel="apple-touch-icon" href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2022/12/favicon.png" />
+<meta name="msapplication-TileImage" content="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2022/12/favicon.png" />
+<style type="text/css" id="wp-custom-css">
+.cl_rd {
+color: #F00;
+}
+.responsive-nav .sub-menu a {
+background-color: #f5f5f5;
+color: #707070;
+font-weight:bold
+}
+body{
+  word-wrap : break-word;
+  overflow-wrap : break-word;
+}
+
+img {
+    -webkit-backface-visibility: hidden;
+}
+@media print {
+.scroll-back-to-top-wrapper{
+display: none !important;
+}
+}
+
+.spmenu2 {
+             padding:  10px 0 0;
+    }
+@media screen and (max-width: 991px) {
+    .spmenu {
+       /* border-bottom: solid 1px #ffcf74;*/
+        padding:  0 0 10px;
+width: 100%;
+    }
+}</style>
+</head>
+<body data-rsssl=1 class="home page-template page-template-templates page-template-rich-front-page page-template-templatesrich-front-page-php page page-id-22 _masterslider _ms_version_3.10.0">
+<div id="container">
+<header id="header" class="header header--2row ">
+<div class="container">
+<div class="row header__content">
+<div class="col-xs-10 col-md-12 header__col">
+<div class ="row">
+<div class="col-md-6 col-sm-12">
+
+<div class="site-branding">
+<h1 class="site-branding__heading">
+<a href="./index.html" rel="home"><img src="https://keisatsubyoin.or.jp/wordpress/wp-content/uploads/2020/03/logo.png" alt="Tokyo Metropolitan Police Hospital" class="site-branding__logo" /></a></h1>
+<!-- end .site-branding --></div>
+                        </div>
+<div class="col-md-6 col-sm-12 h-btn-flex">
+<div id="site-cr">
+<a href="./index.html" class="h-btn current">Website for Patients</a>
+<a href="https://www.keisatsubyoin.or.jp/m/" class="h-btn">Website for Healthcare Professionals</a>
+</div>
+                        <ul class="topnav2">
+<li class="f-cv-tel"><i class="fas fa-phone-volume"></i>03-5343-5611<span style="font-size:12px"> (Main)</span><!--<span class="h-time">【Reception Hours】8:00~11:30/12:30~16:00</span>--></li>
+</ul>
+                        </div>
+                 </div>
+         <!-- end .header__col --></div>
+<div class="col-xs-2 col-md-12 header__col global-nav-wrapper clearfix">
+
+<nav class="global-nav js-responsive-nav nav--hide" role="navigation">
+<div class="menu-gnavi-container"><ul id="menu-gnavi" class="menu"><li id="menu-item-35" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-35"><a href="./index.html"><div class="m-icon"><i class="fas fa-home"></i>Home</div></a></li>
+<li id="menu-item-157" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-157"><a href="./outpatient.html"><div class="m-icon"><i class="fas fa-stethoscope"></i>Outpatient Visits</div></a>
+<ul class="sub-menu">
+<li id="menu-item-170" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-170"><a href="./outpatient.html">For First-Time Patients</a></li>
+<li id="menu-item-172" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-172"><a href="./outpatient.html">For Returning Patients</a></li>
+<li id="menu-item-12181" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-12181"><a href="./outpatient.html">About Nighttime &amp; Holiday Clinics</a></li>
+<li id="menu-item-171" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-171"><a href="./outpatient.html">For Patients with Referral Letters</a></li>
+<li id="menu-item-10898" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-10898"><a href="./outpatient.html">About Focused Referral Medical Institutions</a></li>
+<li id="menu-item-169" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-169"><a href="./outpatient.html">Community Primary Care Physicians</a></li>
+<li id="menu-item-158" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-158"><a href="./outpatient.html">About Medications</a></li>
+</ul>
+</li>
+<li id="menu-item-32" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-32"><a href="./departments.html"><div class="m-icon"><i class="fas fa-syringe"></i>Departments &amp; Divisions</div></a></li>
+<li id="menu-item-190" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-190"><a href="./inpatient.html"><div class="m-icon"><i class="fas fa-bed"></i>Inpatient Guide</div></a>
+<ul class="sub-menu">
+<li id="menu-item-194" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-194"><a href="./inpatient.html">Admission &amp; Discharge</a></li>
+<li id="menu-item-191" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-191"><a href="./inpatient.html">For Visitors</a></li>
+<li id="menu-item-193" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-193"><a href="./inpatient.html">Life During Hospitalization</a></li>
+<li id="menu-item-196" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-196"><a href="./inpatient.html">About Patient Rooms</a></li>
+<li id="menu-item-192" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-192"><a href="./inpatient.html">Messages to Inpatients</a></li>
+<li id="menu-item-195" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-195"><a href="./inpatient.html">About DPC</a></li>
+</ul>
+</li>
+<li id="menu-item-332" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-332"><a href="./about.html"><div class="m-icon"><i class="fas fa-hospital-alt"></i>About the Hospital</div></a>
+<ul class="sub-menu">
+<li id="menu-item-330" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-330"><a href="./about.html">Message from the Hospital Director</a></li>
+<li id="menu-item-338" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-338"><a href="./about.html">Overview &amp; History</a></li>
+<li id="menu-item-318" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-318"><a href="./about.html">Philosophy &amp; Core Policies</a></li>
+<li id="menu-item-5336" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-5336"><a href="./about.html">Policy on Refusal of Blood Transfusions</a></li>
+<li id="menu-item-317" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-317"><a href="./about.html">Patients' Rights &amp; Responsibilities</a></li>
+<li id="menu-item-7761" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-7761"><a href="./about.html">Request for Comprehensive Consent</a></li>
+<li id="menu-item-319" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-319"><a href="./about.html">Partnership with Patients</a></li>
+<li id="menu-item-329" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-329"><a href="./about.html">Facility Guide</a></li>
+<li id="menu-item-321" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-321"><a href="./about.html">Professional Accreditations</a></li>
+<li id="menu-item-322" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-322"><a href="./about.html">Advanced Medical Equipment</a></li>
+<li id="menu-item-323" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-323"><a href="./about.html">Accredited Hospital Functions</a></li>
+<li id="menu-item-325" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-325"><a href="./about.html">Tokyo Police Hospital by the Numbers</a></li>
+<li id="menu-item-4097" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4097"><a href="https://www.keisatsubyoin.or.jp/privacy/">Privacy Policy</a></li>
+<li id="menu-item-4098" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4098"><a href="https://www.keisatsubyoin.or.jp/nextgeneration/">Next Generation Development Support Measures</a></li>
+<li id="menu-item-4099" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4099"><a href="https://www.keisatsubyoin.or.jp/josei/">Women's Advancement Promotion Plan</a></li>
+<li id="menu-item-4197" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4197"><a href="./about.html">Notices Required by the Minister of Health, Labour and Welfare</a></li>
+</ul>
+</li>
+<li id="menu-item-357" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-357"><a href="./support.html"><div class="m-icon"><i class="fas fa-comment-dots"></i>Consultation &amp; Support</div></a>
+<ul class="sub-menu">
+<li id="menu-item-364" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-364"><a href="./support.html">Information Desk</a></li>
+<li id="menu-item-365" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-365"><a href="./support.html">About Second Opinions</a></li>
+<li id="menu-item-362" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-362"><a href="./support.html">Nutrition Counseling &amp; Guidance</a></li>
+<li id="menu-item-361" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-361"><a href="./support.html">Medical Social Services</a></li>
+<li id="menu-item-359" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-359"><a href="./support.html">Access to Medical Records</a></li>
+<li id="menu-item-358" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-358"><a href="./support.html">Clinical Support Team</a></li>
+<li id="menu-item-360" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-360"><a href="./support.html">Frequently Asked Questions</a></li>
+<li id="menu-item-363" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-363"><a href="./support.html">Patient Safety</a></li>
+<li id="menu-item-1573" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1573"><a href="./support.html">Telephone Use</a></li>
+<li id="menu-item-4209" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4209"><a href="./support.html">Suggestion Box</a></li>
+<li id="menu-item-1577" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-1577"><a href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2023/03/患者さま図書コーナーのご案内.pdf">Patient Library Corner</a></li>
+<li id="menu-item-4100" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4100"><a href="https://www.keisatsubyoin.or.jp/news_090821_dog/">Assistance Dogs for Persons with Disabilities</a></li>
+<li id="menu-item-4101" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4101"><a href="https://www.keisatsubyoin.or.jp/research/">Clinical Trials &amp; Research</a></li>
+</ul>
+</li>
+<li id="menu-item-31" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-31"><a href="./access.html"><div class="m-icon"><i class="fas fa-map-marker-alt"></i>Access</div></a></li>
+</ul></div><!-- end .global-nav --></nav>
+<div id="responsive-btn"></div>
+</div>
+<!-- end .header__col --></div>
+<!-- end .container --></div>
+<!-- end #header --></header>
+<div id="contents">
+  <main class="container" role="main">
+    <h1>Outpatient Services</h1>
+    <p>Content coming soon.</p>
+  </main>
+<!-- end #contents --></div>
+<footer id="footer" class="footer">
+
+
+<div class="f-menuArea">
+<div class="container">
+<ul class="f-menu">
+<li>
+<div class="spmenu"><i class="fas fa-chevron-right"></i><a href="./outpatient.html">Outpatient Visits</a></div>
+<ul class="f-sub-menu">
+<li><a href="./outpatient.html">For First-Time Patients</a></li>
+<li><a href="./outpatient.html">For Returning Patients</a></li>
+<li><a href="./outpatient.html">Nighttime &amp; Holiday (After-Hours) Clinics</a></li>
+<li><a href="./outpatient.html">For Patients with Referral Letters</a></li>
+<li><a href="./outpatient.html">About Focused Referral Medical Institutions</a></li>
+<li><a href="./outpatient.html">Keep a Community Primary Care Physician</a></li>
+<li><a href="./outpatient.html">About Medications</a></li>
+</ul>
+<div class="spmenu2"><i class="fas fa-chevron-right"></i><a href="./departments.html">Departments &amp; Divisions</a></div>
+</li>
+<li><i class="fas fa-chevron-right"></i><a href="./inpatient.html">Inpatient Guide</a>
+<ul class="f-sub-menu">
+<li><a href="./inpatient.html">About Admission &amp; Discharge</a></li>
+<li><a href="./inpatient.html">For Visitors</a></li>
+<li><a href="./inpatient.html">Life During Hospitalization</a></li>
+<li><a href="./inpatient.html">About Patient Rooms</a></li>
+<li><a href="./inpatient.html">About Messages to Patients</a></li>
+<li><a href="./inpatient.html">About DPC</a></li>
+</ul>
+</li>
+<li><i class="fas fa-chevron-right"></i><a href="./about.html">About the Hospital</a>
+<ul class="f-sub-menu">
+<li><a href="./about.html">Message from the Hospital Director</a></li>
+<li><a href="./about.html">Hospital Overview</a></li>
+<li><a href="./about.html">Philosophy / Core Policies</a></li>
+<li><a href="./about.html">Policy on Refusal of Blood Transfusions</a></li>
+<li><a href="./about.html">Patients' Rights &amp; Responsibilities</a></li>
+<li><a href="./about.html">Request for Comprehensive Consent</a></li>
+<li><a href="./about.html">Partnership with Patients</a></li>
+<!--<li><a href="./about.html">Organization / Committees</a></li>-->
+<li><a href="./about.html">Floor Guide / On-Site Services</a></li>
+<li><a href="./about.html">Professional Accreditations</a></li>
+<li><a href="./about.html">Advanced Medical Equipment</a></li>
+<li><a href="./about.html">Hospital Function Accreditation</a></li>
+<li><a href="./about.html">Tokyo Police Hospital by the Numbers (Clinical Indicators)</a></li>
+<!--<li><a href="./about.html">History</a></li>-->
+<li><a href="https://www.keisatsubyoin.or.jp/privacy/">Privacy Policy</a></li>
+<li><a href="https://www.keisatsubyoin.or.jp/nextgeneration/">Next Generation Development Support Measures</a></li>
+<li><a href="https://www.keisatsubyoin.or.jp/josei/">Women's Advancement Promotion Plan</a></li>
+<li><a href="./about.html">Notices Required by the Minister of Health, Labour and Welfare</a></li>
+<li><a href="https://www.keisatsubyoin.or.jp/sitemap/">Site Map</a></li>
+</ul>
+</li>
+<li><div class="spmenu"><i class="fas fa-chevron-right"></i><a href="./support.html">Consultation &amp; Support</a></div>
+<ul class="f-sub-menu">
+<li><a href="./support.html">Information Desk</a></li>
+<li><a href="./support.html">Second Opinions</a></li>
+<li><a href="./support.html">Meals &amp; Nutrition Guidance</a></li>
+<li><a href="./support.html">Medical Social Services</a></li>
+<li><a href="./support.html">Access to Medical Records</a></li>
+<li><a href="./support.html">Clinical Support</a></li>
+<li><a href="./support.html">Frequently Asked Questions</a></li>
+<li><a href="./support.html">Patient Safety &amp; Infection Control</a></li>
+<li><a href="./support.html">Telephone Use</a></li>
+<li><a href="./support.html">Suggestion Box</a></li>
+<li><a href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2023/03/患者さま図書コーナーのご案内.pdf">Patient Library Corner</a></li>
+<!--<li><a href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2020/02/vol.11_Kanjasama-Tosyo.pdf#page=1&zoom=200">Patient Library Corner</a></li>-->
+<li><a href="https://www.keisatsubyoin.or.jp/news_090821_dog/">Assistance Dogs for Persons with Disabilities</a></li>
+<li><a href="https://www.keisatsubyoin.or.jp/research/">Clinical Trials &amp; Research</a></li>
+</ul>
+<div class="spmenu2"><i class="fas fa-chevron-right"></i><a href="./access.html">Access</a></div>
+</li>
+</ul>
+</div>
+</div>
+<div class="copyright">
+<div class="container">
+&copy; Tokyo Metropolitan Police Hospital 4-22-1 Nakano, Nakano-ku, Tokyo
+<!-- end .container --></div>
+<!-- end .copyright --></div>
+<!-- end #footer --></footer>
+<!-- end #container --></div>
+<div class="scroll-back-to-top-wrapper">
+<span class="scroll-back-to-top-inner">
+<i class="fa fa-2x fa-arrow-circle-up"></i>
+</span>
+</div><script>
+jQuery( function( $ ) {
+$( '.js-responsive-nav' ).responsive_nav( {
+direction: 'right'
+} );
+} );
+</script>
+<link rel='stylesheet' id='metaslider-flex-slider-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/ml-slider/assets/sliders/flexslider/flexslider.css?ver=3.93.0' type='text/css' media='all' property='stylesheet' />
+<link rel='stylesheet' id='metaslider-public-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/ml-slider/assets/metaslider/public.css?ver=3.93.0' type='text/css' media='all' property='stylesheet' />
+<style id='metaslider-public-inline-css' type='text/css'>
+@media only screen and (max-width: 767px) {body:after { display: none; content: "smartphone"; } .hide-arrows-smartphone .flex-direction-nav, .hide-navigation-smartphone .flex-control-paging, .hide-navigation-smartphone .flex-control-nav, .hide-navigation-smartphone .filmstrip{ display: none!important; }}@media only screen and (min-width : 768px) and (max-width: 1023px) {body:after { display: none; content: "tablet"; } .hide-arrows-tablet .flex-direction-nav, .hide-navigation-tablet .flex-control-paging, .hide-navigation-tablet .flex-control-nav, .hide-navigation-tablet .filmstrip{ display: none!important; }}@media only screen and (min-width : 1024px) and (max-width: 1439px) {body:after { display: none; content: "laptop"; } .hide-arrows-laptop .flex-direction-nav, .hide-navigation-laptop .flex-control-paging, .hide-navigation-laptop .flex-control-nav, .hide-navigation-laptop .filmstrip{ display: none!important; }}@media only screen and (min-width : 1440px) {body:after { display: none; content: "desktop"; } .hide-arrows-desktop .flex-direction-nav, .hide-navigation-desktop .flex-control-paging, .hide-navigation-desktop .flex-control-nav, .hide-navigation-desktop .filmstrip{ display: none!important; }}
+@media only screen and (max-width: 767px) {body:after { display: none; content: "smartphone"; } .hide-arrows-smartphone .flex-direction-nav, .hide-navigation-smartphone .flex-control-paging, .hide-navigation-smartphone .flex-control-nav, .hide-navigation-smartphone .filmstrip{ display: none!important; }}@media only screen and (min-width : 768px) and (max-width: 1023px) {body:after { display: none; content: "tablet"; } .hide-arrows-tablet .flex-direction-nav, .hide-navigation-tablet .flex-control-paging, .hide-navigation-tablet .flex-control-nav, .hide-navigation-tablet .filmstrip{ display: none!important; }}@media only screen and (min-width : 1024px) and (max-width: 1439px) {body:after { display: none; content: "laptop"; } .hide-arrows-laptop .flex-direction-nav, .hide-navigation-laptop .flex-control-paging, .hide-navigation-laptop .flex-control-nav, .hide-navigation-laptop .filmstrip{ display: none!important; }}@media only screen and (min-width : 1440px) {body:after { display: none; content: "desktop"; } .hide-arrows-desktop .flex-direction-nav, .hide-navigation-desktop .flex-control-paging, .hide-navigation-desktop .flex-control-nav, .hide-navigation-desktop .filmstrip{ display: none!important; }}
+</style>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/embed-any-document/js/pdfobject.min.js?ver=2.7.4' id='awsm-ead-pdf-object-js'></script>
+<script type='text/javascript' id='awsm-ead-public-js-extra'>
+/* <![CDATA[ */
+var eadPublic = [];
+/* ]]> */
+</script>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/embed-any-document/js/embed-public.min.js?ver=2.7.4' id='awsm-ead-public-js'></script>
+<script type='text/javascript' id='scroll-back-to-top-js-extra'>
+/* <![CDATA[ */
+var scrollBackToTop = {"scrollDuration":"500","fadeDuration":"0.5"};
+/* ]]> */
+</script>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/scroll-back-to-top/assets/js/scroll-back-to-top.js' id='scroll-back-to-top-js'></script>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri/js/app.min.js?ver=6.2.8' id='habakiri-js'></script>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/ml-slider/assets/sliders/flexslider/jquery.flexslider.min.js?ver=3.93.0' id='metaslider-flex-slider-js'></script>
+<script type='text/javascript' id='metaslider-flex-slider-js-after'>
+var metaslider_38 = function($) {$('#metaslider_38').addClass('flexslider');
+            $('#metaslider_38').flexslider({ 
+                slideshowSpeed:6000,
+                animation:"fade",
+                controlNav:true,
+                directionNav:true,
+                pauseOnHover:true,
+                direction:"horizontal",
+                reverse:false,
+                keyboard:false,
+                touch:true,
+                animationSpeed:2000,
+                prevText:"Previous",
+                nextText:"Next",
+                smoothHeight:false,
+                fadeFirstSlide:false,
+                slideshow:true,
+                pausePlay:false
+            });
+            $(document).trigger('metaslider/initialized', '#metaslider_38');
+        };
+        var timer_metaslider_38 = function() {
+            var slider = !window.jQuery ? window.setTimeout(timer_metaslider_38, 100) : !jQuery.isReady ? window.setTimeout(timer_metaslider_38, 1) : metaslider_38(window.jQuery);
+        };
+        timer_metaslider_38();
+var metaslider_40 = function($) {$('#metaslider_40').addClass('flexslider');
+            $('#metaslider_40').flexslider({ 
+                slideshowSpeed:6000,
+                animation:"fade",
+                controlNav:false,
+                directionNav:false,
+                pauseOnHover:true,
+                direction:"horizontal",
+                reverse:false,
+                keyboard:false,
+                touch:true,
+                animationSpeed:2000,
+                prevText:"Previous",
+                nextText:"Next",
+                smoothHeight:false,
+                fadeFirstSlide:false,
+                slideshow:true,
+                pausePlay:false
+            });
+            $(document).trigger('metaslider/initialized', '#metaslider_40');
+        };
+        var timer_metaslider_40 = function() {
+            var slider = !window.jQuery ? window.setTimeout(timer_metaslider_40, 100) : !jQuery.isReady ? window.setTimeout(timer_metaslider_40, 1) : metaslider_40(window.jQuery);
+        };
+        timer_metaslider_40();
+</script>
+<script type='text/javascript' id='metaslider-script-js-extra'>
+/* <![CDATA[ */
+var wpData = {"baseUrl":"https:\/\/www.keisatsubyoin.or.jp"};
+var wpData = {"baseUrl":"https:\/\/www.keisatsubyoin.or.jp"};
+/* ]]> */
+</script>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/ml-slider/assets/metaslider/script.min.js?ver=3.93.0' id='metaslider-script-js'></script>
+<div id="footerFloatingMenu">
+<ul>
+<li class="ft-tel"><a href="tel:03-5343-5611"><i class="fas fa-phone-volume fa-lg"></i>Call Us</a></li>
+<!--<li class="ft-web"><a href="#" target="_blank"><i class="far fa-calendar-alt"></i>Online Booking</a></li>-->
+<li class="ft-access"><a href="/access/"><i class="fas fa-map-marker-alt"></i>Access</a></li>
+</ul>
+</div>
+<script type="text/javascript" src="https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri-child-1/js-child/jquery.rwdImageMaps.min.js"></script>
+<script>
+//Accordion
+jQuery(function(){
+ 
+    //.accordion1 paragraphs toggle their sibling ul elements when clicked
+jQuery('.accordion1 p').click(function(){
+ 
+jQuery(this).next('ul').slideToggle();
+ 
+});
+});
+//End accordion
+
+//Image map responsiveness
+jQuery(document).ready(function(e) {
+jQuery('img[usemap]').rwdImageMaps()
+});
+//End image map responsiveness
+jQuery(window).on('load', function() {
+var url = jQuery(location).attr('href');
+if(url.indexOf("#") != -1){
+var anchor = url.split("#");
+var target = jQuery('#' + anchor[anchor.length - 1]);
+if(target.length){
+var pos = Math.floor(target.offset().top) - 180;
+jQuery("html, body").animate({scrollTop:pos}, 300);
+}
+}
+});
+
+</script>
+<script>
+jQuery(function() {
+jQuery('.nav-tab > li').on('click',function(){
+jQuery('.nav-tab > li').removeClass('active')
+jQuery(this).addClass('active')
+var index = jQuery('.nav-tab > li').index(this);
+jQuery('#categoryTab > ul').removeClass('show'); 
+jQuery('#categoryTab > ul').eq(index).addClass('show'); 
+});
+});
+</script>
+
+<script>
+(function() {
+  var map = [
+    {prefix: "/", to: "./index.html"},
+    {prefix: "/profile/", to: "./about.html"},
+    {prefix: "/shinryoka/", to: "./departments.html"},
+    {prefix: "/gairai/", to: "./outpatient.html"},
+    {prefix: "/nyuin/", to: "./inpatient.html"},
+    {prefix: "/support/", to: "./support.html"},
+    {prefix: "/access/", to: "./access.html"}
+  ];
+  function remap(u) {
+    var p = u.pathname || "/";
+    var m = map.slice().sort(function(a, b) {
+      return b.prefix.length - a.prefix.length;
+    }).find(function(x) {
+      return p.indexOf(x.prefix) === 0;
+    });
+    return m ? m.to : null;
+  }
+  document.addEventListener('DOMContentLoaded', function() {
+    document.querySelectorAll('a[href]').forEach(function(a) {
+      try {
+        var u = new URL(a.getAttribute('href'), location.href);
+        if (/(^|\.)keisatsubyoin\.or\.jp$/i.test(u.hostname)) {
+          var to = remap(u);
+          if (to) {
+            a.setAttribute('href', to);
+          }
+        }
+      } catch (e) {}
+    });
+  });
+})();
+</script>
+
+</body>
+</html>

--- a/support.html
+++ b/support.html
@@ -1,0 +1,659 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en" prefix="og: https://ogp.me/ns#">
+<head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# article: http://ogp.me/ns/article#">
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<link rel="shortcut icon" href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2022/12/favicon.png" />
+<link rel="pingback" href="https://www.keisatsubyoin.or.jp/wordpress/xmlrpc.php" />
+<link href="https://use.fontawesome.com/releases/v5.0.10/css/all.css" rel="stylesheet">
+<link rel="stylesheet" href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri-child-1/css/pageheader-style.css" />
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-VTBF3Q2K4B"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-VTBF3Q2K4B');
+</script>
+<!--[if lt IE 9]>
+<script src="https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri/js/html5shiv.min.js"></script>
+<![endif]-->
+<title>Support Services | Tokyo Metropolitan Police Hospital</title>
+
+<!-- All in One SEO 4.7.6 - aioseo.com -->
+<meta name="description" content="Content coming soon." />
+<meta name="robots" content="max-image-preview:large" />
+<meta name="msvalidate.01" content="6025B7F66D63703BEED4E4073634721A" />
+<link rel="canonical" href="./support.html" />
+<meta name="generator" content="All in One SEO (AIOSEO) 4.7.6" />
+
+<meta name="google-site-verification" content="97tlZIAoAnOmR7w1s9-GNtXfEEnBRDb7DyN4QJ3Lv3s" />
+<meta property="og:locale" content="en_US" />
+<meta property="og:site_name" content="Tokyo Metropolitan Police Hospital | Medical Care That Protects Those You Love | Tokyo Metropolitan Police Hospital in Nakano Ward Welcomes All Community Members" />
+<meta property="og:type" content="website" />
+<meta property="og:title" content="Support Services | Tokyo Metropolitan Police Hospital" />
+<meta property="og:description" content="Medical care that protects those you love | Tokyo Metropolitan Police Hospital in Nakano Ward welcomes anyone in the community." />
+<meta property="og:url" content="./support.html" />
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content="Support Services | Tokyo Metropolitan Police Hospital" />
+<meta name="twitter:description" content="Content coming soon." />
+<script type="application/ld+json" class="aioseo-schema">
+{"@context":"https:\/\/schema.org","@graph":[{"@type":"BreadcrumbList","@id":"https:\/\/www.keisatsubyoin.or.jp\/#breadcrumblist","itemListElement":[{"@type":"ListItem","@id":"https:\/\/www.keisatsubyoin.or.jp\/#listItem","position":1,"name":"Home"}]},{"@type":"Organization","@id":"https:\/\/www.keisatsubyoin.or.jp\/#organization","name":"Tokyo Metropolitan Police Hospital","description":"Medical care that protects those you love | Tokyo Metropolitan Police Hospital in Nakano Ward welcomes anyone in the community.","url":"https:\/\/www.keisatsubyoin.or.jp\/"},{"@type":"WebPage","@id":"https:\/\/www.keisatsubyoin.or.jp\/#webpage","url":"https:\/\/www.keisatsubyoin.or.jp\/","name":"Tokyo Metropolitan Police Hospital | Medical Care That Protects Those You Love | Tokyo Metropolitan Police Hospital in Nakano Ward Welcomes All Community Members","description":"Medical care that protects those you love | Tokyo Metropolitan Police Hospital in Nakano Ward welcomes anyone in the community.","inLanguage":"en","isPartOf":{"@id":"https:\/\/www.keisatsubyoin.or.jp\/#website"},"breadcrumb":{"@id":"https:\/\/www.keisatsubyoin.or.jp\/#breadcrumblist"},"datePublished":"2019-12-03T08:15:37+09:00","dateModified":"2025-05-01T10:08:09+09:00"},{"@type":"WebSite","@id":"https:\/\/www.keisatsubyoin.or.jp\/#website","url":"https:\/\/www.keisatsubyoin.or.jp\/","name":"Tokyo Metropolitan Police Hospital","description":"Medical care that protects those you love | Tokyo Metropolitan Police Hospital in Nakano Ward welcomes anyone in the community.","inLanguage":"en","publisher":{"@id":"https:\/\/www.keisatsubyoin.or.jp\/#organization"},"potentialAction":{"@type":"SearchAction","target":{"@type":"EntryPoint","urlTemplate":"https:\/\/www.keisatsubyoin.or.jp\/?s={search_term_string}"},"query-input":"required name=search_term_string"}}]}
+</script>
+<!-- All in One SEO -->
+
+<link rel='dns-prefetch' href='//netdna.bootstrapcdn.com' />
+<link rel="alternate" type="application/rss+xml" title="Tokyo Metropolitan Police Hospital &raquo; Feed" href="https://www.keisatsubyoin.or.jp/feed/" />
+<script type="text/javascript">
+window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/14.0.0\/72x72\/","ext":".png","svgUrl":"https:\/\/s.w.org\/images\/core\/emoji\/14.0.0\/svg\/","svgExt":".svg","source":{"concatemoji":"https:\/\/www.keisatsubyoin.or.jp\/wordpress\/wp-includes\/js\/wp-emoji-release.min.js?ver=6.2.8"}};
+/*! This file is auto-generated */
+!function(e,a,t){var n,r,o,i=a.createElement("canvas"),p=i.getContext&&i.getContext("2d");function s(e,t){p.clearRect(0,0,i.width,i.height),p.fillText(e,0,0);e=i.toDataURL();return p.clearRect(0,0,i.width,i.height),p.fillText(t,0,0),e===i.toDataURL()}function c(e){var t=a.createElement("script");t.src=e,t.defer=t.type="text/javascript",a.getElementsByTagName("head")[0].appendChild(t)}for(o=Array("flag","emoji"),t.supports={everything:!0,everythingExceptFlag:!0},r=0;r<o.length;r++)t.supports[o[r]]=function(e){if(p&&p.fillText)switch(p.textBaseline="top",p.font="600 32px Arial",e){case"flag":return s("\ud83c\udff3\ufe0f\u200d\u26a7\ufe0f","\ud83c\udff3\ufe0f\u200b\u26a7\ufe0f")?!1:!s("\ud83c\uddfa\ud83c\uddf3","\ud83c\uddfa\u200b\ud83c\uddf3")&&!s("\ud83c\udff4\udb40\udc67\udb40\udc62\udb40\udc65\udb40\udc6e\udb40\udc67\udb40\udc7f","\ud83c\udff4\u200b\udb40\udc67\u200b\udb40\udc62\u200b\udb40\udc65\u200b\udb40\udc6e\u200b\udb40\udc67\u200b\udb40\udc7f");case"emoji":return!s("\ud83e\udef1\ud83c\udffb\u200d\ud83e\udef2\ud83c\udfff","\ud83e\udef1\ud83c\udffb\u200b\ud83e\udef2\ud83c\udfff")}return!1}(o[r]),t.supports.everything=t.supports.everything&&t.supports[o[r]],"flag"!==o[r]&&(t.supports.everythingExceptFlag=t.supports.everythingExceptFlag&&t.supports[o[r]]);t.supports_everythingExceptFlag=t.supports.everythingExceptFlag&&!t.supports.flag,t.DOMReady=!1,t.readyCallback=function(){t.DOMReady=!0},t.supports.everything||(n=function(){t.readyCallback()},a.addEventListener?(a.addEventListener("DOMContentLoaded",n,!1),e.addEventListener("load",n,!1)):(e.attachEvent("onload",n),a.attachEvent("onreadystatechange",function(){"complete"===a.readyState&&t.readyCallback()})),(e=t.source||{}).concatemoji?c(e.concatemoji):e.wpemoji&&e.twemoji&&(c(e.twemoji),c(e.wpemoji)))}(window,document,window._wpemojiSettings);
+</script>
+<style type="text/css">
+img.wp-smiley,
+img.emoji {
+display: inline !important;
+border: none !important;
+box-shadow: none !important;
+height: 1em !important;
+width: 1em !important;
+margin: 0 0.07em !important;
+vertical-align: -0.1em !important;
+background: none !important;
+padding: 0 !important;
+}
+</style>
+<link rel='stylesheet' id='wp-block-library-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-includes/css/dist/block-library/style.min.css?ver=6.2.8' type='text/css' media='all' />
+<style id='pdfemb-pdf-embedder-viewer-style-inline-css' type='text/css'>
+.wp-block-pdfemb-pdf-embedder-viewer{max-width:none}
+
+</style>
+<link rel='stylesheet' id='awsm-ead-public-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/embed-any-document/css/embed-public.min.css?ver=2.7.4' type='text/css' media='all' />
+<link rel='stylesheet' id='classic-theme-styles-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-includes/css/classic-themes.min.css?ver=6.2.8' type='text/css' media='all' />
+<style id='global-styles-inline-css' type='text/css'>
+body{
+--wp--preset--color--black: #000000;
+--wp--preset--color--cyan-bluish-gray: #abb8c3;
+--wp--preset--color--white: #ffffff;
+--wp--preset--color--pale-pink: #f78da7;
+--wp--preset--color--vivid-red: #cf2e2e;
+--wp--preset--color--luminous-vivid-orange: #ff6900;
+--wp--preset--color--luminous-vivid-amber: #fcb900;
+--wp--preset--color--light-green-cyan: #7bdcb5;
+--wp--preset--color--vivid-green-cyan: #00d084;
+--wp--preset--color--pale-cyan-blue: #8ed1fc;
+--wp--preset--color--vivid-cyan-blue: #0693e3;
+--wp--preset--color--vivid-purple: #9b51e0;
+--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%);
+--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan: linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%);
+--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange: linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%);
+--wp--preset--gradient--luminous-vivid-orange-to-vivid-red: linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%);
+--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray: linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%);
+--wp--preset--gradient--cool-to-warm-spectrum: linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186) 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%);
+--wp--preset--gradient--blush-light-purple: linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%);
+--wp--preset--gradient--blush-bordeaux: linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%);
+--wp--preset--gradient--luminous-dusk: linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%);
+--wp--preset--gradient--pale-ocean: linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181) 100%);
+--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128) 0%,rgb(113,206,126) 100%);
+--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%);
+--wp--preset--duotone--dark-grayscale: url('#wp-duotone-dark-grayscale');
+--wp--preset--duotone--grayscale: url('#wp-duotone-grayscale');
+--wp--preset--duotone--purple-yellow: url('#wp-duotone-purple-yellow');
+--wp--preset--duotone--blue-red: url('#wp-duotone-blue-red');
+--wp--preset--duotone--midnight: url('#wp-duotone-midnight');
+--wp--preset--duotone--magenta-yellow: url('#wp-duotone-magenta-yellow');
+--wp--preset--duotone--purple-green: url('#wp-duotone-purple-green');
+--wp--preset--duotone--blue-orange: url('#wp-duotone-blue-orange');
+--wp--preset--font-size--small: 13px;
+--wp--preset--font-size--medium: 20px;
+--wp--preset--font-size--large: 36px;
+--wp--preset--font-size--x-large: 42px;
+--wp--preset--spacing--20: 0.44rem;
+--wp--preset--spacing--30: 0.67rem;
+--wp--preset--spacing--40: 1rem;
+--wp--preset--spacing--50: 1.5rem;
+--wp--preset--spacing--60: 2.25rem;
+--wp--preset--spacing--70: 3.38rem;
+--wp--preset--spacing--80: 5.06rem;
+--wp--preset--shadow--natural: 6px 6px 9px rgba(0, 0, 0, 0.2);
+--wp--preset--shadow--deep: 12px 12px 50px rgba(0, 0, 0, 0.4);
+--wp--preset--shadow--sharp: 6px 6px 0px rgba(0, 0, 0, 0.2);
+--wp--preset--shadow--outlined: 6px 6px 0px -3px rgba(255, 255, 255, 1), 6px 6px rgba(0, 0, 0, 1);
+--wp--preset--shadow--crisp: 6px 6px 0px rgba(0, 0, 0, 1);
+}
+:where(.is-layout-flex){gap: 0.5em;}
+body .is-layout-flow > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}
+body .is-layout-flow > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}
+body .is-layout-flow > .aligncenter{margin-left: auto !important;margin-right: auto !important;}
+body .is-layout-constrained > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}
+body .is-layout-constrained > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}
+body .is-layout-constrained > .aligncenter{margin-left: auto !important;margin-right: auto !important;}
+body .is-layout-constrained > :where(:not(.alignleft):not(.alignright):not(.alignfull)){max-width: var(--wp--style--global--content-size);margin-left: auto !important;margin-right: auto !important;}
+body .is-layout-constrained > .alignwide{max-width: var(--wp--style--global--wide-size);}
+body .is-layout-flex{display: flex;}
+body .is-layout-flex{flex-wrap: wrap;align-items: center;}
+body .is-layout-flex > *{margin: 0;}
+:where(.wp-block-columns.is-layout-flex){gap: 2em;}
+.has-black-color{color: var(--wp--preset--color--black) !important;}
+.has-cyan-bluish-gray-color{color: var(--wp--preset--color--cyan-bluish-gray) !important;}
+.has-white-color{color: var(--wp--preset--color--white) !important;}
+.has-pale-pink-color{color: var(--wp--preset--color--pale-pink) !important;}
+.has-vivid-red-color{color: var(--wp--preset--color--vivid-red) !important;}
+.has-luminous-vivid-orange-color{color: var(--wp--preset--color--luminous-vivid-orange) !important;}
+.has-luminous-vivid-amber-color{color: var(--wp--preset--color--luminous-vivid-amber) !important;}
+.has-light-green-cyan-color{color: var(--wp--preset--color--light-green-cyan) !important;}
+.has-vivid-green-cyan-color{color: var(--wp--preset--color--vivid-green-cyan) !important;}
+.has-pale-cyan-blue-color{color: var(--wp--preset--color--pale-cyan-blue) !important;}
+.has-vivid-cyan-blue-color{color: var(--wp--preset--color--vivid-cyan-blue) !important;}
+.has-vivid-purple-color{color: var(--wp--preset--color--vivid-purple) !important;}
+.has-black-background-color{background-color: var(--wp--preset--color--black) !important;}
+.has-cyan-bluish-gray-background-color{background-color: var(--wp--preset--color--cyan-bluish-gray) !important;}
+.has-white-background-color{background-color: var(--wp--preset--color--white) !important;}
+.has-pale-pink-background-color{background-color: var(--wp--preset--color--pale-pink) !important;}
+.has-vivid-red-background-color{background-color: var(--wp--preset--color--vivid-red) !important;}
+.has-luminous-vivid-orange-background-color{background-color: var(--wp--preset--color--luminous-vivid-orange) !important;}
+.has-luminous-vivid-amber-background-color{background-color: var(--wp--preset--color--luminous-vivid-amber) !important;}
+.has-light-green-cyan-background-color{background-color: var(--wp--preset--color--light-green-cyan) !important;}
+.has-vivid-green-cyan-background-color{background-color: var(--wp--preset--color--vivid-green-cyan) !important;}
+.has-pale-cyan-blue-background-color{background-color: var(--wp--preset--color--pale-cyan-blue) !important;}
+.has-vivid-cyan-blue-background-color{background-color: var(--wp--preset--color--vivid-cyan-blue) !important;}
+.has-vivid-purple-background-color{background-color: var(--wp--preset--color--vivid-purple) !important;}
+.has-black-border-color{border-color: var(--wp--preset--color--black) !important;}
+.has-cyan-bluish-gray-border-color{border-color: var(--wp--preset--color--cyan-bluish-gray) !important;}
+.has-white-border-color{border-color: var(--wp--preset--color--white) !important;}
+.has-pale-pink-border-color{border-color: var(--wp--preset--color--pale-pink) !important;}
+.has-vivid-red-border-color{border-color: var(--wp--preset--color--vivid-red) !important;}
+.has-luminous-vivid-orange-border-color{border-color: var(--wp--preset--color--luminous-vivid-orange) !important;}
+.has-luminous-vivid-amber-border-color{border-color: var(--wp--preset--color--luminous-vivid-amber) !important;}
+.has-light-green-cyan-border-color{border-color: var(--wp--preset--color--light-green-cyan) !important;}
+.has-vivid-green-cyan-border-color{border-color: var(--wp--preset--color--vivid-green-cyan) !important;}
+.has-pale-cyan-blue-border-color{border-color: var(--wp--preset--color--pale-cyan-blue) !important;}
+.has-vivid-cyan-blue-border-color{border-color: var(--wp--preset--color--vivid-cyan-blue) !important;}
+.has-vivid-purple-border-color{border-color: var(--wp--preset--color--vivid-purple) !important;}
+.has-vivid-cyan-blue-to-vivid-purple-gradient-background{background: var(--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple) !important;}
+.has-light-green-cyan-to-vivid-green-cyan-gradient-background{background: var(--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan) !important;}
+.has-luminous-vivid-amber-to-luminous-vivid-orange-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange) !important;}
+.has-luminous-vivid-orange-to-vivid-red-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-orange-to-vivid-red) !important;}
+.has-very-light-gray-to-cyan-bluish-gray-gradient-background{background: var(--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray) !important;}
+.has-cool-to-warm-spectrum-gradient-background{background: var(--wp--preset--gradient--cool-to-warm-spectrum) !important;}
+.has-blush-light-purple-gradient-background{background: var(--wp--preset--gradient--blush-light-purple) !important;}
+.has-blush-bordeaux-gradient-background{background: var(--wp--preset--gradient--blush-bordeaux) !important;}
+.has-luminous-dusk-gradient-background{background: var(--wp--preset--gradient--luminous-dusk) !important;}
+.has-pale-ocean-gradient-background{background: var(--wp--preset--gradient--pale-ocean) !important;}
+.has-electric-grass-gradient-background{background: var(--wp--preset--gradient--electric-grass) !important;}
+.has-midnight-gradient-background{background: var(--wp--preset--gradient--midnight) !important;}
+.has-small-font-size{font-size: var(--wp--preset--font-size--small) !important;}
+.has-medium-font-size{font-size: var(--wp--preset--font-size--medium) !important;}
+.has-large-font-size{font-size: var(--wp--preset--font-size--large) !important;}
+.has-x-large-font-size{font-size: var(--wp--preset--font-size--x-large) !important;}
+.wp-block-navigation a:where(:not(.wp-element-button)){color: inherit;}
+:where(.wp-block-columns.is-layout-flex){gap: 2em;}
+.wp-block-pullquote{font-size: 1.5em;line-height: 1.6;}
+</style>
+<link rel='stylesheet' id='font-awesome-css' href='//netdna.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.css' type='text/css' media='screen' />
+<link rel='stylesheet' id='habakiri-assets-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri/css/assets.min.css?ver=6.2.8' type='text/css' media='all' />
+<link rel='stylesheet' id='habakiri-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri/style.min.css?ver=20250926050751' type='text/css' media='all' />
+<link rel='stylesheet' id='habakiri-child-1-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri-child-1/style.css?ver=20250926050751' type='text/css' media='all' />
+<link rel='stylesheet' id='msl-main-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/master-slider/public/assets/css/masterslider.main.css?ver=3.10.0' type='text/css' media='all' />
+<link rel='stylesheet' id='msl-custom-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/master-slider/custom.css?ver=4.5' type='text/css' media='all' />
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-includes/js/jquery/jquery.min.js?ver=3.6.4' id='jquery-core-js'></script>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-includes/js/jquery/jquery-migrate.min.js?ver=3.4.0' id='jquery-migrate-js'></script>
+<link rel="https://api.w.org/" href="https://www.keisatsubyoin.or.jp/wp-json/" /><link rel="alternate" type="application/json" href="https://www.keisatsubyoin.or.jp/wp-json/wp/v2/pages/22" /><link rel="EditURI" type="application/rsd+xml" title="RSD" href="https://www.keisatsubyoin.or.jp/wordpress/xmlrpc.php?rsd" />
+<link rel="wlwmanifest" type="application/wlwmanifest+xml" href="https://www.keisatsubyoin.or.jp/wordpress/wp-includes/wlwmanifest.xml" />
+<meta name="generator" content="WordPress 6.2.8" />
+<link rel='shortlink' href='https://www.keisatsubyoin.or.jp/' />
+<link rel="alternate" type="application/json+oembed" href="https://www.keisatsubyoin.or.jp/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.keisatsubyoin.or.jp%2F" />
+<link rel="alternate" type="text/xml+oembed" href="https://www.keisatsubyoin.or.jp/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.keisatsubyoin.or.jp%2F&#038;format=xml" />
+<script>var ms_grabbing_curosr = 'https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/master-slider/public/assets/css/common/grabbing.cur', ms_grab_curosr = 'https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/master-slider/public/assets/css/common/grab.cur';</script>
+<meta name="generator" content="MasterSlider 3.10.0 - Responsive Touch Image Slider | avt.li/msf" />
+
+<style>
+.scroll-back-to-top-wrapper {
+    position: fixed;
+opacity: 0;
+visibility: hidden;
+overflow: hidden;
+text-align: center;
+z-index: 99999999;
+    background-color: #777777;
+color: #eeeeee;
+width: 50px;
+height: 48px;
+line-height: 48px;
+right: 30px;
+bottom: 60px;
+padding-top: 2px;
+border-top-left-radius: 10px;
+border-top-right-radius: 10px;
+border-bottom-right-radius: 10px;
+border-bottom-left-radius: 10px;
+-webkit-transition: all 0.5s ease-in-out;
+-moz-transition: all 0.5s ease-in-out;
+-ms-transition: all 0.5s ease-in-out;
+-o-transition: all 0.5s ease-in-out;
+transition: all 0.5s ease-in-out;
+}
+.scroll-back-to-top-wrapper:hover {
+background-color: #888888;
+  color: #eeeeee;
+}
+.scroll-back-to-top-wrapper.show {
+    visibility:visible;
+    cursor:pointer;
+opacity: 1.0;
+}
+.scroll-back-to-top-wrapper i.fa {
+line-height: inherit;
+}
+.scroll-back-to-top-wrapper .fa-lg {
+vertical-align: 0;
+}
+</style><style>
+/* Safari 6.1+ (10.0 is the latest version of Safari at this time) */
+@media (max-width: 991px) and (min-color-index: 0) and (-webkit-min-device-pixel-ratio: 0) { @media () {
+display: block !important;
+.header__col {
+width: 100%;
+}
+}}
+</style>
+<style>a{color:#337ab7}a:focus,a:active,a:hover{color:#23527c}.site-branding a{color:#000}.responsive-nav a{color:#ffffff;font-size:14px}.responsive-nav a small{color:#707070;font-size:10px}.responsive-nav a:hover small,.responsive-nav a:active small,.responsive-nav .current-menu-item small,.responsive-nav .current-menu-ancestor small,.responsive-nav .current-menu-parent small,.responsive-nav .current_page_item small,.responsive-nav .current_page_parent small{color:#707070}.responsive-nav .menu>.menu-item>a,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.menu-item>a{background-color:#f4a000;padding:12px 7px}.responsive-nav .menu>.menu-item>a:hover,.responsive-nav .menu>.menu-item>a:active,.responsive-nav .menu>.current-menu-item>a,.responsive-nav .menu>.current-menu-ancestor>a,.responsive-nav .menu>.current-menu-parent>a,.responsive-nav .menu>.current_page_item>a,.responsive-nav .menu>.current_page_parent>a,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.menu-item>a:hover,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.menu-item>a:active,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.current-menu-item>a,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.current-menu-ancestor>a,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.current-menu-parent>a,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.current_page_item>a,.header--transparency.header--fixed--is_scrolled .responsive-nav .menu>.current_page_parent>a{background-color:#f5f5f5;color:#707070}.responsive-nav .sub-menu a{background-color:#f5f5f5;color:#707070}.responsive-nav .sub-menu a:hover,.responsive-nav .sub-menu a:active,.responsive-nav .sub-menu .current-menu-item a,.responsive-nav .sub-menu .current-menu-ancestor a,.responsive-nav .sub-menu .current-menu-parent a,.responsive-nav .sub-menu .current_page_item a,.responsive-nav .sub-menu .current_page_parent a{background-color:#f5f5f5;color:#707070}.off-canvas-nav{font-size:12px}.responsive-nav,.header--transparency.header--fixed--is_scrolled .responsive-nav{background-color:#f4a000}#responsive-btn{background-color:transparent;border-color:#eeeeee;color:#000}#responsive-btn:hover{background-color:#f5f5f5;border-color:#eee;color:#000}.habakiri-slider__transparent-layer{background-color:rgba( 0,0,0, 0.1 )}.page-header{background-color:#dddddd;color:#fff}.pagination>li>a{color:#337ab7}.pagination>li>span{background-color:#337ab7;border-color:#337ab7}.pagination>li>a:focus,.pagination>li>a:hover,.pagination>li>span:focus,.pagination>li>span:hover{color:#23527c}.header{background-color:#fff}.header--transparency.header--fixed--is_scrolled{background-color:#fff !important}.footer{background-color:#f49000}.footer-widget-area a{color:#777}.footer-widget-area,.footer-widget-area .widget_calendar #wp-calendar caption{color:#555}.footer-widget-area .widget_calendar #wp-calendar,.footer-widget-area .widget_calendar #wp-calendar *{border-color:#555}@media(min-width:992px){.responsive-nav{display:block}.off-canvas-nav,#responsive-btn{display:none !important}.header--2row{padding-bottom:0}.header--2row .header__col,.header--center .header__col{display:block}.header--2row .responsive-nav,.header--center .responsive-nav{margin-right:-1000px;margin-left:-1000px;padding-right:1000px;padding-left:1000px}.header--center .site-branding{text-align:center}}</style><link rel="icon" href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2022/12/favicon.png" sizes="32x32" />
+<link rel="icon" href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2022/12/favicon.png" sizes="192x192" />
+<link rel="apple-touch-icon" href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2022/12/favicon.png" />
+<meta name="msapplication-TileImage" content="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2022/12/favicon.png" />
+<style type="text/css" id="wp-custom-css">
+.cl_rd {
+color: #F00;
+}
+.responsive-nav .sub-menu a {
+background-color: #f5f5f5;
+color: #707070;
+font-weight:bold
+}
+body{
+  word-wrap : break-word;
+  overflow-wrap : break-word;
+}
+
+img {
+    -webkit-backface-visibility: hidden;
+}
+@media print {
+.scroll-back-to-top-wrapper{
+display: none !important;
+}
+}
+
+.spmenu2 {
+             padding:  10px 0 0;
+    }
+@media screen and (max-width: 991px) {
+    .spmenu {
+       /* border-bottom: solid 1px #ffcf74;*/
+        padding:  0 0 10px;
+width: 100%;
+    }
+}</style>
+</head>
+<body data-rsssl=1 class="home page-template page-template-templates page-template-rich-front-page page-template-templatesrich-front-page-php page page-id-22 _masterslider _ms_version_3.10.0">
+<div id="container">
+<header id="header" class="header header--2row ">
+<div class="container">
+<div class="row header__content">
+<div class="col-xs-10 col-md-12 header__col">
+<div class ="row">
+<div class="col-md-6 col-sm-12">
+
+<div class="site-branding">
+<h1 class="site-branding__heading">
+<a href="./index.html" rel="home"><img src="https://keisatsubyoin.or.jp/wordpress/wp-content/uploads/2020/03/logo.png" alt="Tokyo Metropolitan Police Hospital" class="site-branding__logo" /></a></h1>
+<!-- end .site-branding --></div>
+                        </div>
+<div class="col-md-6 col-sm-12 h-btn-flex">
+<div id="site-cr">
+<a href="./index.html" class="h-btn current">Website for Patients</a>
+<a href="https://www.keisatsubyoin.or.jp/m/" class="h-btn">Website for Healthcare Professionals</a>
+</div>
+                        <ul class="topnav2">
+<li class="f-cv-tel"><i class="fas fa-phone-volume"></i>03-5343-5611<span style="font-size:12px"> (Main)</span><!--<span class="h-time">【Reception Hours】8:00~11:30/12:30~16:00</span>--></li>
+</ul>
+                        </div>
+                 </div>
+         <!-- end .header__col --></div>
+<div class="col-xs-2 col-md-12 header__col global-nav-wrapper clearfix">
+
+<nav class="global-nav js-responsive-nav nav--hide" role="navigation">
+<div class="menu-gnavi-container"><ul id="menu-gnavi" class="menu"><li id="menu-item-35" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-35"><a href="./index.html"><div class="m-icon"><i class="fas fa-home"></i>Home</div></a></li>
+<li id="menu-item-157" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-157"><a href="./outpatient.html"><div class="m-icon"><i class="fas fa-stethoscope"></i>Outpatient Visits</div></a>
+<ul class="sub-menu">
+<li id="menu-item-170" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-170"><a href="./outpatient.html">For First-Time Patients</a></li>
+<li id="menu-item-172" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-172"><a href="./outpatient.html">For Returning Patients</a></li>
+<li id="menu-item-12181" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-12181"><a href="./outpatient.html">About Nighttime &amp; Holiday Clinics</a></li>
+<li id="menu-item-171" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-171"><a href="./outpatient.html">For Patients with Referral Letters</a></li>
+<li id="menu-item-10898" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-10898"><a href="./outpatient.html">About Focused Referral Medical Institutions</a></li>
+<li id="menu-item-169" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-169"><a href="./outpatient.html">Community Primary Care Physicians</a></li>
+<li id="menu-item-158" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-158"><a href="./outpatient.html">About Medications</a></li>
+</ul>
+</li>
+<li id="menu-item-32" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-32"><a href="./departments.html"><div class="m-icon"><i class="fas fa-syringe"></i>Departments &amp; Divisions</div></a></li>
+<li id="menu-item-190" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-190"><a href="./inpatient.html"><div class="m-icon"><i class="fas fa-bed"></i>Inpatient Guide</div></a>
+<ul class="sub-menu">
+<li id="menu-item-194" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-194"><a href="./inpatient.html">Admission &amp; Discharge</a></li>
+<li id="menu-item-191" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-191"><a href="./inpatient.html">For Visitors</a></li>
+<li id="menu-item-193" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-193"><a href="./inpatient.html">Life During Hospitalization</a></li>
+<li id="menu-item-196" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-196"><a href="./inpatient.html">About Patient Rooms</a></li>
+<li id="menu-item-192" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-192"><a href="./inpatient.html">Messages to Inpatients</a></li>
+<li id="menu-item-195" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-195"><a href="./inpatient.html">About DPC</a></li>
+</ul>
+</li>
+<li id="menu-item-332" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-332"><a href="./about.html"><div class="m-icon"><i class="fas fa-hospital-alt"></i>About the Hospital</div></a>
+<ul class="sub-menu">
+<li id="menu-item-330" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-330"><a href="./about.html">Message from the Hospital Director</a></li>
+<li id="menu-item-338" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-338"><a href="./about.html">Overview &amp; History</a></li>
+<li id="menu-item-318" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-318"><a href="./about.html">Philosophy &amp; Core Policies</a></li>
+<li id="menu-item-5336" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-5336"><a href="./about.html">Policy on Refusal of Blood Transfusions</a></li>
+<li id="menu-item-317" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-317"><a href="./about.html">Patients' Rights &amp; Responsibilities</a></li>
+<li id="menu-item-7761" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-7761"><a href="./about.html">Request for Comprehensive Consent</a></li>
+<li id="menu-item-319" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-319"><a href="./about.html">Partnership with Patients</a></li>
+<li id="menu-item-329" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-329"><a href="./about.html">Facility Guide</a></li>
+<li id="menu-item-321" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-321"><a href="./about.html">Professional Accreditations</a></li>
+<li id="menu-item-322" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-322"><a href="./about.html">Advanced Medical Equipment</a></li>
+<li id="menu-item-323" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-323"><a href="./about.html">Accredited Hospital Functions</a></li>
+<li id="menu-item-325" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-325"><a href="./about.html">Tokyo Police Hospital by the Numbers</a></li>
+<li id="menu-item-4097" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4097"><a href="https://www.keisatsubyoin.or.jp/privacy/">Privacy Policy</a></li>
+<li id="menu-item-4098" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4098"><a href="https://www.keisatsubyoin.or.jp/nextgeneration/">Next Generation Development Support Measures</a></li>
+<li id="menu-item-4099" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4099"><a href="https://www.keisatsubyoin.or.jp/josei/">Women's Advancement Promotion Plan</a></li>
+<li id="menu-item-4197" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4197"><a href="./about.html">Notices Required by the Minister of Health, Labour and Welfare</a></li>
+</ul>
+</li>
+<li id="menu-item-357" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-357"><a href="./support.html"><div class="m-icon"><i class="fas fa-comment-dots"></i>Consultation &amp; Support</div></a>
+<ul class="sub-menu">
+<li id="menu-item-364" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-364"><a href="./support.html">Information Desk</a></li>
+<li id="menu-item-365" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-365"><a href="./support.html">About Second Opinions</a></li>
+<li id="menu-item-362" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-362"><a href="./support.html">Nutrition Counseling &amp; Guidance</a></li>
+<li id="menu-item-361" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-361"><a href="./support.html">Medical Social Services</a></li>
+<li id="menu-item-359" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-359"><a href="./support.html">Access to Medical Records</a></li>
+<li id="menu-item-358" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-358"><a href="./support.html">Clinical Support Team</a></li>
+<li id="menu-item-360" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-360"><a href="./support.html">Frequently Asked Questions</a></li>
+<li id="menu-item-363" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-363"><a href="./support.html">Patient Safety</a></li>
+<li id="menu-item-1573" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1573"><a href="./support.html">Telephone Use</a></li>
+<li id="menu-item-4209" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4209"><a href="./support.html">Suggestion Box</a></li>
+<li id="menu-item-1577" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-1577"><a href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2023/03/患者さま図書コーナーのご案内.pdf">Patient Library Corner</a></li>
+<li id="menu-item-4100" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4100"><a href="https://www.keisatsubyoin.or.jp/news_090821_dog/">Assistance Dogs for Persons with Disabilities</a></li>
+<li id="menu-item-4101" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4101"><a href="https://www.keisatsubyoin.or.jp/research/">Clinical Trials &amp; Research</a></li>
+</ul>
+</li>
+<li id="menu-item-31" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-31"><a href="./access.html"><div class="m-icon"><i class="fas fa-map-marker-alt"></i>Access</div></a></li>
+</ul></div><!-- end .global-nav --></nav>
+<div id="responsive-btn"></div>
+</div>
+<!-- end .header__col --></div>
+<!-- end .container --></div>
+<!-- end #header --></header>
+<div id="contents">
+  <main class="container" role="main">
+    <h1>Support Services</h1>
+    <p>Content coming soon.</p>
+  </main>
+<!-- end #contents --></div>
+<footer id="footer" class="footer">
+
+
+<div class="f-menuArea">
+<div class="container">
+<ul class="f-menu">
+<li>
+<div class="spmenu"><i class="fas fa-chevron-right"></i><a href="./outpatient.html">Outpatient Visits</a></div>
+<ul class="f-sub-menu">
+<li><a href="./outpatient.html">For First-Time Patients</a></li>
+<li><a href="./outpatient.html">For Returning Patients</a></li>
+<li><a href="./outpatient.html">Nighttime &amp; Holiday (After-Hours) Clinics</a></li>
+<li><a href="./outpatient.html">For Patients with Referral Letters</a></li>
+<li><a href="./outpatient.html">About Focused Referral Medical Institutions</a></li>
+<li><a href="./outpatient.html">Keep a Community Primary Care Physician</a></li>
+<li><a href="./outpatient.html">About Medications</a></li>
+</ul>
+<div class="spmenu2"><i class="fas fa-chevron-right"></i><a href="./departments.html">Departments &amp; Divisions</a></div>
+</li>
+<li><i class="fas fa-chevron-right"></i><a href="./inpatient.html">Inpatient Guide</a>
+<ul class="f-sub-menu">
+<li><a href="./inpatient.html">About Admission &amp; Discharge</a></li>
+<li><a href="./inpatient.html">For Visitors</a></li>
+<li><a href="./inpatient.html">Life During Hospitalization</a></li>
+<li><a href="./inpatient.html">About Patient Rooms</a></li>
+<li><a href="./inpatient.html">About Messages to Patients</a></li>
+<li><a href="./inpatient.html">About DPC</a></li>
+</ul>
+</li>
+<li><i class="fas fa-chevron-right"></i><a href="./about.html">About the Hospital</a>
+<ul class="f-sub-menu">
+<li><a href="./about.html">Message from the Hospital Director</a></li>
+<li><a href="./about.html">Hospital Overview</a></li>
+<li><a href="./about.html">Philosophy / Core Policies</a></li>
+<li><a href="./about.html">Policy on Refusal of Blood Transfusions</a></li>
+<li><a href="./about.html">Patients' Rights &amp; Responsibilities</a></li>
+<li><a href="./about.html">Request for Comprehensive Consent</a></li>
+<li><a href="./about.html">Partnership with Patients</a></li>
+<!--<li><a href="./about.html">Organization / Committees</a></li>-->
+<li><a href="./about.html">Floor Guide / On-Site Services</a></li>
+<li><a href="./about.html">Professional Accreditations</a></li>
+<li><a href="./about.html">Advanced Medical Equipment</a></li>
+<li><a href="./about.html">Hospital Function Accreditation</a></li>
+<li><a href="./about.html">Tokyo Police Hospital by the Numbers (Clinical Indicators)</a></li>
+<!--<li><a href="./about.html">History</a></li>-->
+<li><a href="https://www.keisatsubyoin.or.jp/privacy/">Privacy Policy</a></li>
+<li><a href="https://www.keisatsubyoin.or.jp/nextgeneration/">Next Generation Development Support Measures</a></li>
+<li><a href="https://www.keisatsubyoin.or.jp/josei/">Women's Advancement Promotion Plan</a></li>
+<li><a href="./about.html">Notices Required by the Minister of Health, Labour and Welfare</a></li>
+<li><a href="https://www.keisatsubyoin.or.jp/sitemap/">Site Map</a></li>
+</ul>
+</li>
+<li><div class="spmenu"><i class="fas fa-chevron-right"></i><a href="./support.html">Consultation &amp; Support</a></div>
+<ul class="f-sub-menu">
+<li><a href="./support.html">Information Desk</a></li>
+<li><a href="./support.html">Second Opinions</a></li>
+<li><a href="./support.html">Meals &amp; Nutrition Guidance</a></li>
+<li><a href="./support.html">Medical Social Services</a></li>
+<li><a href="./support.html">Access to Medical Records</a></li>
+<li><a href="./support.html">Clinical Support</a></li>
+<li><a href="./support.html">Frequently Asked Questions</a></li>
+<li><a href="./support.html">Patient Safety &amp; Infection Control</a></li>
+<li><a href="./support.html">Telephone Use</a></li>
+<li><a href="./support.html">Suggestion Box</a></li>
+<li><a href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2023/03/患者さま図書コーナーのご案内.pdf">Patient Library Corner</a></li>
+<!--<li><a href="https://www.keisatsubyoin.or.jp/wordpress/wp-content/uploads/2020/02/vol.11_Kanjasama-Tosyo.pdf#page=1&zoom=200">Patient Library Corner</a></li>-->
+<li><a href="https://www.keisatsubyoin.or.jp/news_090821_dog/">Assistance Dogs for Persons with Disabilities</a></li>
+<li><a href="https://www.keisatsubyoin.or.jp/research/">Clinical Trials &amp; Research</a></li>
+</ul>
+<div class="spmenu2"><i class="fas fa-chevron-right"></i><a href="./access.html">Access</a></div>
+</li>
+</ul>
+</div>
+</div>
+<div class="copyright">
+<div class="container">
+&copy; Tokyo Metropolitan Police Hospital 4-22-1 Nakano, Nakano-ku, Tokyo
+<!-- end .container --></div>
+<!-- end .copyright --></div>
+<!-- end #footer --></footer>
+<!-- end #container --></div>
+<div class="scroll-back-to-top-wrapper">
+<span class="scroll-back-to-top-inner">
+<i class="fa fa-2x fa-arrow-circle-up"></i>
+</span>
+</div><script>
+jQuery( function( $ ) {
+$( '.js-responsive-nav' ).responsive_nav( {
+direction: 'right'
+} );
+} );
+</script>
+<link rel='stylesheet' id='metaslider-flex-slider-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/ml-slider/assets/sliders/flexslider/flexslider.css?ver=3.93.0' type='text/css' media='all' property='stylesheet' />
+<link rel='stylesheet' id='metaslider-public-css' href='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/ml-slider/assets/metaslider/public.css?ver=3.93.0' type='text/css' media='all' property='stylesheet' />
+<style id='metaslider-public-inline-css' type='text/css'>
+@media only screen and (max-width: 767px) {body:after { display: none; content: "smartphone"; } .hide-arrows-smartphone .flex-direction-nav, .hide-navigation-smartphone .flex-control-paging, .hide-navigation-smartphone .flex-control-nav, .hide-navigation-smartphone .filmstrip{ display: none!important; }}@media only screen and (min-width : 768px) and (max-width: 1023px) {body:after { display: none; content: "tablet"; } .hide-arrows-tablet .flex-direction-nav, .hide-navigation-tablet .flex-control-paging, .hide-navigation-tablet .flex-control-nav, .hide-navigation-tablet .filmstrip{ display: none!important; }}@media only screen and (min-width : 1024px) and (max-width: 1439px) {body:after { display: none; content: "laptop"; } .hide-arrows-laptop .flex-direction-nav, .hide-navigation-laptop .flex-control-paging, .hide-navigation-laptop .flex-control-nav, .hide-navigation-laptop .filmstrip{ display: none!important; }}@media only screen and (min-width : 1440px) {body:after { display: none; content: "desktop"; } .hide-arrows-desktop .flex-direction-nav, .hide-navigation-desktop .flex-control-paging, .hide-navigation-desktop .flex-control-nav, .hide-navigation-desktop .filmstrip{ display: none!important; }}
+@media only screen and (max-width: 767px) {body:after { display: none; content: "smartphone"; } .hide-arrows-smartphone .flex-direction-nav, .hide-navigation-smartphone .flex-control-paging, .hide-navigation-smartphone .flex-control-nav, .hide-navigation-smartphone .filmstrip{ display: none!important; }}@media only screen and (min-width : 768px) and (max-width: 1023px) {body:after { display: none; content: "tablet"; } .hide-arrows-tablet .flex-direction-nav, .hide-navigation-tablet .flex-control-paging, .hide-navigation-tablet .flex-control-nav, .hide-navigation-tablet .filmstrip{ display: none!important; }}@media only screen and (min-width : 1024px) and (max-width: 1439px) {body:after { display: none; content: "laptop"; } .hide-arrows-laptop .flex-direction-nav, .hide-navigation-laptop .flex-control-paging, .hide-navigation-laptop .flex-control-nav, .hide-navigation-laptop .filmstrip{ display: none!important; }}@media only screen and (min-width : 1440px) {body:after { display: none; content: "desktop"; } .hide-arrows-desktop .flex-direction-nav, .hide-navigation-desktop .flex-control-paging, .hide-navigation-desktop .flex-control-nav, .hide-navigation-desktop .filmstrip{ display: none!important; }}
+</style>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/embed-any-document/js/pdfobject.min.js?ver=2.7.4' id='awsm-ead-pdf-object-js'></script>
+<script type='text/javascript' id='awsm-ead-public-js-extra'>
+/* <![CDATA[ */
+var eadPublic = [];
+/* ]]> */
+</script>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/embed-any-document/js/embed-public.min.js?ver=2.7.4' id='awsm-ead-public-js'></script>
+<script type='text/javascript' id='scroll-back-to-top-js-extra'>
+/* <![CDATA[ */
+var scrollBackToTop = {"scrollDuration":"500","fadeDuration":"0.5"};
+/* ]]> */
+</script>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/scroll-back-to-top/assets/js/scroll-back-to-top.js' id='scroll-back-to-top-js'></script>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri/js/app.min.js?ver=6.2.8' id='habakiri-js'></script>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/ml-slider/assets/sliders/flexslider/jquery.flexslider.min.js?ver=3.93.0' id='metaslider-flex-slider-js'></script>
+<script type='text/javascript' id='metaslider-flex-slider-js-after'>
+var metaslider_38 = function($) {$('#metaslider_38').addClass('flexslider');
+            $('#metaslider_38').flexslider({ 
+                slideshowSpeed:6000,
+                animation:"fade",
+                controlNav:true,
+                directionNav:true,
+                pauseOnHover:true,
+                direction:"horizontal",
+                reverse:false,
+                keyboard:false,
+                touch:true,
+                animationSpeed:2000,
+                prevText:"Previous",
+                nextText:"Next",
+                smoothHeight:false,
+                fadeFirstSlide:false,
+                slideshow:true,
+                pausePlay:false
+            });
+            $(document).trigger('metaslider/initialized', '#metaslider_38');
+        };
+        var timer_metaslider_38 = function() {
+            var slider = !window.jQuery ? window.setTimeout(timer_metaslider_38, 100) : !jQuery.isReady ? window.setTimeout(timer_metaslider_38, 1) : metaslider_38(window.jQuery);
+        };
+        timer_metaslider_38();
+var metaslider_40 = function($) {$('#metaslider_40').addClass('flexslider');
+            $('#metaslider_40').flexslider({ 
+                slideshowSpeed:6000,
+                animation:"fade",
+                controlNav:false,
+                directionNav:false,
+                pauseOnHover:true,
+                direction:"horizontal",
+                reverse:false,
+                keyboard:false,
+                touch:true,
+                animationSpeed:2000,
+                prevText:"Previous",
+                nextText:"Next",
+                smoothHeight:false,
+                fadeFirstSlide:false,
+                slideshow:true,
+                pausePlay:false
+            });
+            $(document).trigger('metaslider/initialized', '#metaslider_40');
+        };
+        var timer_metaslider_40 = function() {
+            var slider = !window.jQuery ? window.setTimeout(timer_metaslider_40, 100) : !jQuery.isReady ? window.setTimeout(timer_metaslider_40, 1) : metaslider_40(window.jQuery);
+        };
+        timer_metaslider_40();
+</script>
+<script type='text/javascript' id='metaslider-script-js-extra'>
+/* <![CDATA[ */
+var wpData = {"baseUrl":"https:\/\/www.keisatsubyoin.or.jp"};
+var wpData = {"baseUrl":"https:\/\/www.keisatsubyoin.or.jp"};
+/* ]]> */
+</script>
+<script type='text/javascript' src='https://www.keisatsubyoin.or.jp/wordpress/wp-content/plugins/ml-slider/assets/metaslider/script.min.js?ver=3.93.0' id='metaslider-script-js'></script>
+<div id="footerFloatingMenu">
+<ul>
+<li class="ft-tel"><a href="tel:03-5343-5611"><i class="fas fa-phone-volume fa-lg"></i>Call Us</a></li>
+<!--<li class="ft-web"><a href="#" target="_blank"><i class="far fa-calendar-alt"></i>Online Booking</a></li>-->
+<li class="ft-access"><a href="/access/"><i class="fas fa-map-marker-alt"></i>Access</a></li>
+</ul>
+</div>
+<script type="text/javascript" src="https://www.keisatsubyoin.or.jp/wordpress/wp-content/themes/habakiri-child-1/js-child/jquery.rwdImageMaps.min.js"></script>
+<script>
+//Accordion
+jQuery(function(){
+ 
+    //.accordion1 paragraphs toggle their sibling ul elements when clicked
+jQuery('.accordion1 p').click(function(){
+ 
+jQuery(this).next('ul').slideToggle();
+ 
+});
+});
+//End accordion
+
+//Image map responsiveness
+jQuery(document).ready(function(e) {
+jQuery('img[usemap]').rwdImageMaps()
+});
+//End image map responsiveness
+jQuery(window).on('load', function() {
+var url = jQuery(location).attr('href');
+if(url.indexOf("#") != -1){
+var anchor = url.split("#");
+var target = jQuery('#' + anchor[anchor.length - 1]);
+if(target.length){
+var pos = Math.floor(target.offset().top) - 180;
+jQuery("html, body").animate({scrollTop:pos}, 300);
+}
+}
+});
+
+</script>
+<script>
+jQuery(function() {
+jQuery('.nav-tab > li').on('click',function(){
+jQuery('.nav-tab > li').removeClass('active')
+jQuery(this).addClass('active')
+var index = jQuery('.nav-tab > li').index(this);
+jQuery('#categoryTab > ul').removeClass('show'); 
+jQuery('#categoryTab > ul').eq(index).addClass('show'); 
+});
+});
+</script>
+
+<script>
+(function() {
+  var map = [
+    {prefix: "/", to: "./index.html"},
+    {prefix: "/profile/", to: "./about.html"},
+    {prefix: "/shinryoka/", to: "./departments.html"},
+    {prefix: "/gairai/", to: "./outpatient.html"},
+    {prefix: "/nyuin/", to: "./inpatient.html"},
+    {prefix: "/support/", to: "./support.html"},
+    {prefix: "/access/", to: "./access.html"}
+  ];
+  function remap(u) {
+    var p = u.pathname || "/";
+    var m = map.slice().sort(function(a, b) {
+      return b.prefix.length - a.prefix.length;
+    }).find(function(x) {
+      return p.indexOf(x.prefix) === 0;
+    });
+    return m ? m.to : null;
+  }
+  document.addEventListener('DOMContentLoaded', function() {
+    document.querySelectorAll('a[href]').forEach(function(a) {
+      try {
+        var u = new URL(a.getAttribute('href'), location.href);
+        if (/(^|\.)keisatsubyoin\.or\.jp$/i.test(u.hostname)) {
+          var to = remap(u);
+          if (to) {
+            a.setAttribute('href', to);
+          }
+        }
+      } catch (e) {}
+    });
+  });
+})();
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- update the English homepage navigation, hero quick links, and footer menus to point at internal HTML placeholders instead of the production domain
- add a defensive script that remaps lingering keisatsubyoin.or.jp anchors to their local equivalents on load
- create English stub pages for About, Departments, Outpatient, Inpatient, Support, and Access with matching metadata and shared layout

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68e23db31d10832a9afea789baa876aa